### PR TITLE
Related tables

### DIFF
--- a/constants_1.js
+++ b/constants_1.js
@@ -1,4 +1,0 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.tableExtension = "tableextension";
-exports.pageExtension = "pageextension";

--- a/extension.js
+++ b/extension.js
@@ -7,14 +7,16 @@ const regionWrapper = require('./regionWrapper/regionWrapper');
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
-
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
   
-    context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.createRelatedTables', () => {
-        relatedTables.createRelatedTables()
-            .then(() => vscode.window.showInformationMessage('Related tables created!'),
-                  () => vscode.window.showInformationMessage('Failed to create related tables'));
+    context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.createRelatedTables', async () => {
+        const objectPrefix = await getObjectPrefix();
+        if (objectPrefix !== undefined) {
+            relatedTables.createRelatedTables(objectPrefix)
+                .then(() => vscode.window.showInformationMessage(`Related tables & pages created with prefix: '${objectPrefix}'`),
+                    () => vscode.window.showInformationMessage('Failed to create related tables & pages'));
+        }
     }));
     
     context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.wrapAllFunctions', function () {
@@ -47,4 +49,17 @@ function deactivate() {}
 module.exports = {
 	activate,
 	deactivate
+}
+
+async function getObjectPrefix() {
+    let objectPrefix;
+    let settings = vscode.workspace.getConfiguration('CRS');
+    objectPrefix = settings.get('ObjectNamePrefix');
+    if (!objectPrefix) {
+        settings = vscode.workspace.getConfiguration('alVarHelper');
+        objectPrefix = settings.get('ignoreALPrefix');
+        if (!objectPrefix)
+            objectPrefix = await vscode.window.showInputBox({ placeHolder: 'Object prefix'}).then(newPrefix => newPrefix);
+    }
+    return objectPrefix
 }

--- a/extension.js
+++ b/extension.js
@@ -18,6 +18,34 @@ function activate(context) {
                     () => vscode.window.showInformationMessage('Failed to create related tables & pages'));
         }
     }));
+    const RelatedTablesManager = new relatedTables.RelatedTablesManager();
+    context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.openRelatedTables', () => {
+        const currendDoc = vscode.window.activeTextEditor.document;
+        const extensionObjectInfo = relatedTables.getExtensionObjectInfo(currendDoc);
+        if (extensionObjectInfo) {
+            if (!RelatedTablesManager.openRelateTables(extensionObjectInfo.exendedObjectName, extensionObjectInfo.alObjectType))
+                vscode.window.showInformationMessage('No related tables found');
+        } else
+            vscode.window.showInformationMessage('No page-/tableextension found in open file');
+    }));
+    context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.openRelatedPages', () => {
+        const currendDoc = vscode.window.activeTextEditor.document;
+        const extensionObjectInfo = relatedTables.getExtensionObjectInfo(currendDoc);
+        if (extensionObjectInfo) {
+            if (!RelatedTablesManager.openRelatePages(extensionObjectInfo.exendedObjectName, extensionObjectInfo.alObjectType))
+                vscode.window.showInformationMessage('No related pages found');
+        } else
+            vscode.window.showInformationMessage('No page-/tableextension found in open file');
+    }));
+    context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.openRelatedTablesAndPages', () => {
+        const currendDoc = vscode.window.activeTextEditor.document;
+        const extensionObjectInfo = relatedTables.getExtensionObjectInfo(currendDoc);
+        if (extensionObjectInfo) {
+            if(!RelatedTablesManager.openRelatePagesAndTables(extensionObjectInfo.exendedObjectName, extensionObjectInfo.alObjectType))
+                vscode.window.showInformationMessage('No related tables or pages found');
+        } else
+            vscode.window.showInformationMessage('No page-/tableextension found in open file');
+    }));
     
     context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.wrapAllFunctions', function () {
         let editor = vscode.window.activeTextEditor;

--- a/extension.js
+++ b/extension.js
@@ -1,13 +1,7 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
-const path = require("path");
-const fs = require("fs");
-const constants_1 = require("./constants_1");
-//const workspaceHelpers = require("./workspaceFolderHelpers");
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
+const relatedTables = require('./relatedTables/relatedTables');
 const regionWrapper = require('./regionWrapper/regionWrapper');
+
 
 /**
  * @param {vscode.ExtensionContext} context
@@ -16,152 +10,12 @@ function activate(context) {
 
 	// Use the console to output diagnostic information (console.log) and errors (console.error)
 	// This line of code will only be executed once when your extension is activated
-
-	let disposable = vscode.commands.registerCommand('extension.createRelatedTables', function () {
-        // The code you place here will be executed every time your command is executed
-        const rootPath = getCurrentWorkspaceFolderPath();
-        //vscode.window.showInformationMessage(rootPath);
-        // if rootpath is empty then error
-        if (!rootPath) {
-            return Promise.reject("No AL workspace folder is active");
-        }
-
-        // tableextensions
-        //vscode.window.showInformationMessage(rootPath);
-        const baseDestinationPath = rootPath + '/src/';
-        //vscode.window.showInformationMessage(rootPath);
-        
-        //Create Table Extension Folder
-        let destinationPath = baseDestinationPath + constants_1.tableExtension + '/';
-        createFolder(destinationPath);
-        //Contact
-        destinationPath = destinationPath + 'Contact/'
-        createFolder(destinationPath);
-        createAlFile(destinationPath, constants_1.tableExtension, 18, 'Customer');
-        createAlFile(destinationPath, constants_1.tableExtension, 23, 'Vendor');
-        createAlFile(destinationPath, constants_1.tableExtension, 270, 'Bank Account');
-        createAlFile(destinationPath, constants_1.tableExtension, 5050, 'Contact');
-        //SalesHeader
-        destinationPath = baseDestinationPath + constants_1.tableExtension + '/SalesHeader/';
-        createFolder(destinationPath);
-        createAlFile(destinationPath, constants_1.tableExtension, 36, 'Sales Header');
-        createAlFile(destinationPath, constants_1.tableExtension, 110, 'Sales Shipment Header');
-        createAlFile(destinationPath, constants_1.tableExtension, 112, 'Sales Invoice Header');
-        createAlFile(destinationPath, constants_1.tableExtension, 114, 'Sales Cr.Memo Header');
-        createAlFile(destinationPath, constants_1.tableExtension, 5107, 'Sales Header Archive');
-        createAlFile(destinationPath, constants_1.tableExtension, 6660, 'Return Receipt Header');
-        //SalesLine
-        destinationPath = baseDestinationPath + constants_1.tableExtension + '/SalesLine/';
-        createFolder(destinationPath);
-        createAlFile(destinationPath, constants_1.tableExtension, 37, 'Sales Line');
-        createAlFile(destinationPath, constants_1.tableExtension, 111, 'Sales Shipment Line');
-        createAlFile(destinationPath, constants_1.tableExtension, 113, 'Sales Invoice Line');
-        createAlFile(destinationPath, constants_1.tableExtension, 115, 'Sales Cr.Memo Line');
-        createAlFile(destinationPath, constants_1.tableExtension, 5108, 'Sales Line Archive');
-        createAlFile(destinationPath, constants_1.tableExtension, 6661, 'Return Receipt Line');
-        //PurchaseHeader
-        destinationPath = baseDestinationPath + constants_1.tableExtension + '/PurchaseHeader/';
-        createFolder(destinationPath);
-        createAlFile(destinationPath, constants_1.tableExtension, 38, 'Purchase Header');
-        createAlFile(destinationPath, constants_1.tableExtension, 120, 'Purch. Rcpt. Header');
-        createAlFile(destinationPath, constants_1.tableExtension, 122, 'Purch. Inv. Header');
-        createAlFile(destinationPath, constants_1.tableExtension, 124, 'Purch. Cr. Memo Hdr.');
-        createAlFile(destinationPath, constants_1.tableExtension, 5109, 'Purchase Header Archive');
-        createAlFile(destinationPath, constants_1.tableExtension, 6650, 'Return Shipment Header');
-        //PurchaseLine
-        destinationPath = baseDestinationPath + constants_1.tableExtension + '/PurchaseLine/';
-        createFolder(destinationPath);
-        createAlFile(destinationPath, constants_1.tableExtension, 39, 'Purchase Line');
-        createAlFile(destinationPath, constants_1.tableExtension, 121, 'Purch. Rcpt. Line');
-        createAlFile(destinationPath, constants_1.tableExtension, 123, 'Purch. Inv. Line');
-        createAlFile(destinationPath, constants_1.tableExtension, 125, 'Purch. Cr. Memo Line');
-        createAlFile(destinationPath, constants_1.tableExtension, 5110, 'Purchase Line Archive');
-        createAlFile(destinationPath, constants_1.tableExtension, 6651, 'Return Shipment Line');
-
-        // pageextensions
-        //Create Page Extension Folder
-        destinationPath = baseDestinationPath + constants_1.pageExtension + '/';
-        createFolder(destinationPath);
-        //Contact
-        destinationPath = destinationPath + 'Contact/'
-        createFolder(destinationPath);
-        createAlFile(destinationPath, constants_1.pageExtension, 21, 'Customer Card');
-        createAlFile(destinationPath, constants_1.pageExtension, 22, 'Customer List');
-        createAlFile(destinationPath, constants_1.pageExtension, 26, 'Vendor Card');
-        createAlFile(destinationPath, constants_1.pageExtension, 27, 'Vendor List');
-        createAlFile(destinationPath, constants_1.pageExtension, 370, 'Bank Account Card');
-        createAlFile(destinationPath, constants_1.pageExtension, 371, 'Bank Account List');
-        createAlFile(destinationPath, constants_1.pageExtension, 5050, 'Contact Card');
-        createAlFile(destinationPath, constants_1.pageExtension, 5052, 'Contact List');
-        //SalesHeader
-        destinationPath = baseDestinationPath + constants_1.pageExtension + '/SalesHeader/';
-        createFolder(destinationPath);
-        createAlFile(destinationPath, constants_1.pageExtension, 41, 'Sales Quote');
-        createAlFile(destinationPath, constants_1.pageExtension, 42, 'Sales Order');
-        createAlFile(destinationPath, constants_1.pageExtension, 43, 'Sales Invoice');
-        createAlFile(destinationPath, constants_1.pageExtension, 44, 'Sales Credit Memo');
-        createAlFile(destinationPath, constants_1.pageExtension, 130, 'Posted Sales Shipment');
-        createAlFile(destinationPath, constants_1.pageExtension, 132, 'Posted Sales Invoice');
-        createAlFile(destinationPath, constants_1.pageExtension, 134, 'Posted Sales Credit Memo');
-        createAlFile(destinationPath, constants_1.pageExtension, 143, 'Posted Sales Invoices');
-        createAlFile(destinationPath, constants_1.pageExtension, 144, 'Posted Sales Credit Memos');
-        createAlFile(destinationPath, constants_1.pageExtension, 6630, 'Sales Return Order');
-        createAlFile(destinationPath, constants_1.pageExtension, 9300, 'Sales Quotes');
-        createAlFile(destinationPath, constants_1.pageExtension, 9301, 'Sales Invoice List');
-        createAlFile(destinationPath, constants_1.pageExtension, 9302, 'Sales Credit Memos');
-        createAlFile(destinationPath, constants_1.pageExtension, 9304, 'Sales Return Order List');
-        createAlFile(destinationPath, constants_1.pageExtension, 9305, 'Sales Order List');
-        //SalesLine
-        destinationPath = baseDestinationPath + constants_1.pageExtension + '/SalesLine/';
-        createFolder(destinationPath);
-        createAlFile(destinationPath, constants_1.pageExtension, 46, 'Sales Order Subform');
-        createAlFile(destinationPath, constants_1.pageExtension, 47, 'Sales Invoice Subform');
-        createAlFile(destinationPath, constants_1.pageExtension, 95, 'Sales Quote Subform');
-        createAlFile(destinationPath, constants_1.pageExtension, 96, 'Sales Cr. Memo Subform');
-        createAlFile(destinationPath, constants_1.pageExtension, 131, 'Posted Sales Shpt. Subform');
-        createAlFile(destinationPath, constants_1.pageExtension, 133, 'Posted Sales Invoice Subform');
-        createAlFile(destinationPath, constants_1.pageExtension, 135, 'Posted Sales Cr. Memo Subform');
-        createAlFile(destinationPath, constants_1.pageExtension, 516, 'Sales Lines');
-        createAlFile(destinationPath, constants_1.pageExtension, 526, 'Posted Sales Invoice Lines');
-        createAlFile(destinationPath, constants_1.pageExtension, 6631, 'Sales Return Order Subform');
-        //PurchaseHeader
-        destinationPath = baseDestinationPath + constants_1.pageExtension + '/PurchaseHeader/';
-        createFolder(destinationPath);
-        createAlFile(destinationPath, constants_1.pageExtension, 49, 'Purchase Quote');
-        createAlFile(destinationPath, constants_1.pageExtension, 50, 'Purchase Order');
-        createAlFile(destinationPath, constants_1.pageExtension, 51, 'Purchase Invoice');
-        createAlFile(destinationPath, constants_1.pageExtension, 52, 'Purchase Credit Memo');
-        createAlFile(destinationPath, constants_1.pageExtension, 136, 'Posted Purchase Receipt');
-        createAlFile(destinationPath, constants_1.pageExtension, 138, 'Posted Purchase Invoice');
-        createAlFile(destinationPath, constants_1.pageExtension, 140, 'Posted Purchase Credit Memo');
-        createAlFile(destinationPath, constants_1.pageExtension, 145, 'Posted Purchase Receipts');
-        createAlFile(destinationPath, constants_1.pageExtension, 146, 'Posted Purchase Invoices');
-        createAlFile(destinationPath, constants_1.pageExtension, 147, 'Posted Purchase Credit Memos');
-        createAlFile(destinationPath, constants_1.pageExtension, 6640, 'Purchase Return Order');
-        createAlFile(destinationPath, constants_1.pageExtension, 6660, 'Posted Return Receipt');
-        createAlFile(destinationPath, constants_1.pageExtension, 9306, 'Purchase Quotes');
-        createAlFile(destinationPath, constants_1.pageExtension, 9307, 'Purchase List');
-        createAlFile(destinationPath, constants_1.pageExtension, 9308, 'Purchase Invoices');
-        createAlFile(destinationPath, constants_1.pageExtension, 9309, 'Purchase Credit Memos');
-        createAlFile(destinationPath, constants_1.pageExtension, 9311, 'Purchase Return Order List');
-        //PurchaseLine
-        destinationPath = baseDestinationPath + constants_1.pageExtension + '/PurchaseLine/';
-        createFolder(destinationPath);
-        createAlFile(destinationPath, constants_1.pageExtension, 54, 'Purchase Order Subform');
-        createAlFile(destinationPath, constants_1.pageExtension, 55, 'Purch. Invoice Subform');
-        createAlFile(destinationPath, constants_1.pageExtension, 97, 'Purchase Quote Subform');
-        createAlFile(destinationPath, constants_1.pageExtension, 98, 'Purch. Cr. Memo Subform');
-        createAlFile(destinationPath, constants_1.pageExtension, 137, 'Posted Purchase Rcpt. Subform');
-        createAlFile(destinationPath, constants_1.pageExtension, 139, 'Posted Purch. Invoice Subform');
-        createAlFile(destinationPath, constants_1.pageExtension, 141, 'Posted Purch. Cr. Memo Subform');
-        createAlFile(destinationPath, constants_1.pageExtension, 6641, 'Purchase Return Order Subform');
-        
-
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Related Tables Created!');
-	});
-
-    context.subscriptions.push(disposable);
+  
+    context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.createRelatedTables', () => {
+        relatedTables.createRelatedTables()
+            .then(() => vscode.window.showInformationMessage('Related Tables Created!'),
+                  () => vscode.window.showInformationMessage('Failed to create Related Tables.'));
+    }));
     
     context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.wrapAllFunctions', function () {
         let editor = vscode.window.activeTextEditor;
@@ -169,7 +23,6 @@ function activate(context) {
         editor.edit(editBuilder => {
             numberOfRegions = regionWrapper.WrapAllFunctions(editBuilder, editor.document);
         }).then(() => vscode.window.showInformationMessage(numberOfRegions +' region(s) created.'));
-    
     }));
     context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.wrapAllDataItemsAndColumns', function () {
         let editor = vscode.window.activeTextEditor;
@@ -188,113 +41,6 @@ function activate(context) {
     }));
 }
 exports.activate = activate;
-///////////AL File Creation
-function createAlFile(destinationPath, objectType, objectId, objectName){
-    const newObjectId = objectId + 80000;
-    let newObjectName = objectName.replace(/\s/g,'');
-    newObjectName = newObjectName.replace('.', '');
-    let fileName;
-    let fileContent;
-    // Generate File Name and Content
-    if (objectType == constants_1.tableExtension) {
-        fileName = 'Tab';
-        fileContent = 
-        `
-{
-    fields
-    {
-
-    }
-}
-        `
-    } else {
-        fileName = 'Pag';
-        fileContent = 
-        `
-{
-    layout
-    {
-    }
-
-    actions
-    {
-    }
-}
-        `
-    }
-    fileName = fileName + objectId + '-' + 'Ext' + newObjectId + '.' + newObjectName + '.al';
-    //vscode.window.showInformationMessage(fileName);
-    //Generate Path
-    const filePath = path.join(destinationPath, fileName);
-    return existsFileAsync(filePath)
-            .then(exists => {
-            if (exists) {
-                return filePath;
-            }
-            const contents =    objectType + ' ' + newObjectId + ' "' + newObjectName + '" extends "' +  objectName + '" //' + objectId + fileContent;
-            return writeTextFileAsync(filePath, contents)
-                .then(() => filePath);
-            });  
-}
-///////////File Creation
-function writeTextFileAsync(filename, data) {
-    return new Promise((resolve, reject) => {
-        fs.writeFile(filename, data, { encoding: "utf-8" }, e => {
-            if (e) {
-                return reject(e);
-            }
-            resolve(true);
-        });
-    });
-}
-function existsFileAsync(filename) {
-    return new Promise(resolve => {
-        fs.exists(filename, exists => {
-            resolve(exists);
-        });
-    });
-}
-exports.existsFileAsync = existsFileAsync;
-
-///////////Workspace Finder
-function getCurrentWorkspaceFolderPath() {
-    const currentWorkspaceFolder = getCurrentWorkspaceFolder();
-    if (currentWorkspaceFolder) {
-        return currentWorkspaceFolder.uri.fsPath;
-    }
-    return undefined;
-}
-function getCurrentWorkspaceFolder() {
-    const activeEditor = vscode.window.activeTextEditor;
-    if (activeEditor) {
-        if (activeEditor.document) {
-            lastActiveWorkspace = getWorkspaceFolderFromPath(activeEditor.document.fileName);
-            return lastActiveWorkspace;
-        }
-    }
-}
-function getWorkspaceFolderFromPath(path) {
-    if (!Array.isArray(vscode.workspace.workspaceFolders) || vscode.workspace.workspaceFolders.length === 0) {
-        lastActiveWorkspace = undefined;
-        return lastActiveWorkspace;
-    }
-    // one workspace folder, this is the old folder/rootpath scenario.
-    if (vscode.workspace.workspaceFolders.length === 1) {
-        lastActiveWorkspace = vscode.workspace.workspaceFolders[0];
-        return lastActiveWorkspace;
-    }
-    const uri = vscode.Uri.file(path);
-    const workspace = vscode.workspace.getWorkspaceFolder(uri);
-    return workspace;
-}
-///////////Folder Creation
-function createFolder(dir) {
-    if (fs.existsSync(dir)) return;
-    if (!fs.existsSync(path.dirname(dir))) {
-        this.makeDirSync(path.dirname(dir));
-    }
-    fs.mkdirSync(dir);
-}
 // this method is called when your extension is deactivated
 function deactivate() {}
 
@@ -302,4 +48,3 @@ module.exports = {
 	activate,
 	deactivate
 }
-let lastActiveWorkspace = undefined;

--- a/extension.js
+++ b/extension.js
@@ -13,8 +13,8 @@ function activate(context) {
   
     context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.createRelatedTables', () => {
         relatedTables.createRelatedTables()
-            .then(() => vscode.window.showInformationMessage('Related Tables Created!'),
-                  () => vscode.window.showInformationMessage('Failed to create Related Tables.'));
+            .then(() => vscode.window.showInformationMessage('Related tables created!'),
+                  () => vscode.window.showInformationMessage('Failed to create related tables'));
     }));
     
     context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.wrapAllFunctions', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,96 @@
+{
+    "name": "al-toolbox",
+    "version": "0.1.3",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "Snippets"
     ],
     "activationEvents": [
-        "onCommand:extension.createRelatedTables",
+        "onCommand:al-toolbox.createRelatedTables",
         "onCommand:al-toolbox.wrapAllFunctions",
         "onCommand:al-toolbox.wrapAllDataItemsAndColumns",
         "onCommand:al-toolbox.wrapAll"
@@ -58,7 +58,7 @@
         ],
         "commands":[
             {
-                "command": "extension.createRelatedTables",
+                "command": "al-toolbox.createRelatedTables",
 				"title": "ALTB: Start Project: Create Related Tables"
             },
             {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,12 @@
         "onCommand:al-toolbox.createRelatedTables",
         "onCommand:al-toolbox.wrapAllFunctions",
         "onCommand:al-toolbox.wrapAllDataItemsAndColumns",
-        "onCommand:al-toolbox.wrapAll"
-	],
-	"main": "./extension.js",
+        "onCommand:al-toolbox.wrapAll",
+        "onCommand:al-toolbox.openRelatedTables",
+        "onCommand:al-toolbox.openRelatedPages",
+        "onCommand:al-toolbox.openRelatedTablesAndPages"
+    ],
+    "main": "./extension.js",
     "contributes": {
         "languages": [
             {
@@ -40,7 +43,9 @@
                     "AL"
                 ],
                 "configuration": "./al.configuration.json",
-                "injectTo": [ "source.al" ]
+                "injectTo": [
+                    "source.al"
+                ]
             }
         ],
         "snippets": [
@@ -53,17 +58,31 @@
             {
                 "scopeName": "al.toolbox",
                 "path": "./syntaxes/alsyntax.tmlanguage",
-                "injectTo": [ "source.al" ]
+                "injectTo": [
+                    "source.al"
+                ]
             }
         ],
-        "commands":[
+        "commands": [
             {
                 "command": "al-toolbox.createRelatedTables",
-				"title": "ALTB: Start Project: Create Related Tables"
+                "title": "ALTB: Start Project: Create Related Tables"
+            },
+            {
+                "command": "al-toolbox.openRelatedTables",
+                "title": "ALTB: Open Related Tables"
+            },
+            {
+                "command": "al-toolbox.openRelatedPages",
+                "title": "ALTB: Open Related Pages"
+            },
+            {
+                "command": "al-toolbox.openRelatedTablesAndPages",
+                "title": "ALTB: Open Related Tables and Pages"
             },
             {
                 "command": "al-toolbox.wrapAllFunctions",
-				"title": "ALTB: Create regions for all AL functions and triggers"
+                "title": "ALTB: Create regions for all AL functions and triggers"
             },
             {
                 "command": "al-toolbox.wrapAllDataItemsAndColumns",
@@ -80,14 +99,14 @@
         "test": "node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
-		"@types/glob": "^7.1.1",
-		"@types/mocha": "^7.0.1",
-		"@types/node": "^12.11.7",
-		"@types/vscode": "^1.42.0",
-		"eslint": "^6.8.0",
-		"glob": "^7.1.6",
-		"mocha": "^7.0.1",
-		"typescript": "^3.7.5",
-		"vscode-test": "^1.3.0"
-	}
+        "@types/glob": "^7.1.1",
+        "@types/mocha": "^7.0.1",
+        "@types/node": "^12.11.7",
+        "@types/vscode": "^1.42.0",
+        "eslint": "^6.8.0",
+        "glob": "^7.1.6",
+        "mocha": "^7.0.1",
+        "typescript": "^3.7.5",
+        "vscode-test": "^1.3.0"
+    }
 }

--- a/relatedTables/constants.js
+++ b/relatedTables/constants.js
@@ -1,0 +1,12 @@
+exports.AlObjectTypes = {
+    table: 'table',
+    tableExtension: 'tableextension',
+    page: 'page',
+    pageExtension: 'pageextension',
+    pageCustomization: 'pagecustomization',
+    codeUnit: 'codeunit',
+    report: 'report',
+    query: 'query',
+    profile: 'profile',
+    XMLPort: 'xmlport'
+}

--- a/relatedTables/constants.js
+++ b/relatedTables/constants.js
@@ -11,8 +11,33 @@ exports.AlObjectTypes = {
     XMLPort: 'xmlport'
 }
 
+exports.AlObjectTypesToFilePrefix = (AlObjectType) => {
+    switch (AlObjectType) {
+        case this.AlObjectTypes.table:
+		case this.AlObjectTypes.tableExtension:
+		    return 'Tab';
+        case this.AlObjectTypes.page:
+		case this.AlObjectTypes.pageExtension:
+		case this.AlObjectTypes.pageCustomization:
+		    return 'Pag';
+        case this.AlObjectTypes.codeUnit:
+		    return 'Cod';
+        case this.AlObjectTypes.report:
+		    return 'Rep';
+        case this.AlObjectTypes.query:
+		    return 'Que';
+        case this.AlObjectTypes.profile:
+		    return 'Prof';
+        case this.AlObjectTypes.XMLPort:
+            return 'Xml';
+        default:
+            return '';
+    }
+}
+
 exports.RelatedTables = [
     {
+        table: 'Contact',
         folder: 'Contact',
         objectType: this.AlObjectTypes.tableExtension,
         objects: [
@@ -23,6 +48,7 @@ exports.RelatedTables = [
         ]
     },
     {
+        table: 'Sales Header',
         folder: 'SalesHeader',
         objectType: this.AlObjectTypes.tableExtension,
         objects: [
@@ -35,7 +61,8 @@ exports.RelatedTables = [
         ]
     },
     {
-        folder: 'SalesLine',
+        table: 'Sales Line',
+		folder: 'SalesLine',
         objectType: this.AlObjectTypes.tableExtension,
         objects: [
             { id: 37, name: 'Sales Line' },
@@ -47,7 +74,8 @@ exports.RelatedTables = [
         ]
     },
     {
-        folder: 'PurchaseHeader',
+        table: 'Purchase Header',
+		folder: 'PurchaseHeader',
         objectType: this.AlObjectTypes.tableExtension,
         objects: [
             { id: 38, name: 'Purchase Header' },
@@ -59,7 +87,8 @@ exports.RelatedTables = [
         ]
     },
     {
-        folder: 'PurchaseLine',
+        table: 'Purchase Line',
+		folder: 'PurchaseLine',
         objectType: this.AlObjectTypes.tableExtension,
         objects: [
             { id: 39, name: 'Purchase Line' },
@@ -70,33 +99,54 @@ exports.RelatedTables = [
             { id: 6651, name: 'Return Shipment Line' }
         ]
     },
+    //#region Pages form tables related to Contact
     {
+        table: 'Contact',
         folder: 'Contact',
         objectType: this.AlObjectTypes.pageExtension,
         objects: [
-            { id: 21, name: 'Customer Card' },
-            { id: 22, name: 'Customer List' },
-            { id: 26, name: 'Vendor Card' },
-            { id: 27, name: 'Vendor List' },
-            { id: 370, name: 'Bank Account Card' },
-            { id: 371, name: 'Bank Account List' },
             { id: 5050, name: 'Contact Card' },
             { id: 5052, name: 'Contact List' }
         ]
     },
     {
-        folder: 'SalesHeader',
+        table: 'Customer',
+        folder: 'Contact',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 21, name: 'Customer Card' },
+            { id: 22, name: 'Customer List' }
+        ]
+    },
+    {
+        table: 'Vendor',
+        folder: 'Contact',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 26, name: 'Vendor Card' },
+            { id: 27, name: 'Vendor List' },
+        ]
+    },
+    {
+        table: 'Bank Account',
+        folder: 'Contact',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 370, name: 'Bank Account Card' },
+            { id: 371, name: 'Bank Account List' }
+        ]
+    },
+    //#endregion
+    //#region Pages form tables related to Sales Header
+    {
+        table: 'Sales Header',
+		folder: 'SalesHeader',
         objectType: this.AlObjectTypes.pageExtension,
         objects: [
             { id: 41, name: 'Sales Quote' },
             { id: 42, name: 'Sales Order' },
             { id: 43, name: 'Sales Invoice' },
             { id: 44, name: 'Sales Credit Memo' },
-            { id: 130, name: 'Posted Sales Shipment' },
-            { id: 132, name: 'Posted Sales Invoice' },
-            { id: 134, name: 'Posted Sales Credit Memo' },
-            { id: 143, name: 'Posted Sales Invoices' },
-            { id: 144, name: 'Posted Sales Credit Memos' },
             { id: 6630, name: 'Sales Return Order' },
             { id: 9300, name: 'Sales Quotes' },
             { id: 9301, name: 'Sales Invoice List' },
@@ -106,37 +156,100 @@ exports.RelatedTables = [
         ]
     },
     {
-        folder: 'SalesLine',
+        table: 'Sales Shipment Header',
+		folder: 'SalesHeader',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 130, name: 'Posted Sales Shipment' },
+            { id: 142, name: 'Posted Sales Shipments' }
+        ]
+    },
+    {
+        table: 'Sales Invoice Header',
+		folder: 'SalesHeader',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 132, name: 'Posted Sales Invoice' },
+            { id: 143, name: 'Posted Sales Invoices' },
+        ]
+    },
+    {
+        table: 'Sales Cr.Memo Header',
+		folder: 'SalesHeader',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 134, name: 'Posted Sales Credit Memo' },
+            { id: 144, name: 'Posted Sales Credit Memos' }
+        ]
+    },
+    {
+        table: 'Return Receipt Header',
+		folder: 'SalesHeader',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 6660, name: 'Posted Return Receipt' }
+        ]
+    },
+    //#endregion
+    //#region Pages form tables related to Sales Lines
+    {
+        table: 'Sales Line',
+		folder: 'SalesLine',
         objectType: this.AlObjectTypes.pageExtension,
         objects: [
             { id: 46, name: 'Sales Order Subform' },
             { id: 47, name: 'Sales Invoice Subform' },
             { id: 95, name: 'Sales Quote Subform' },
             { id: 96, name: 'Sales Cr. Memo Subform' },
-            { id: 131, name: 'Posted Sales Shpt. Subform' },
-            { id: 133, name: 'Posted Sales Invoice Subform' },
-            { id: 135, name: 'Posted Sales Cr. Memo Subform' },
             { id: 516, name: 'Sales Lines' },
-            { id: 526, name: 'Posted Sales Invoice Lines' },
             { id: 6631, name: 'Sales Return Order Subform' }
         ]
     },
     {
-        folder: 'PurchaseHeader',
+        table: 'Sales Shipment Line',
+		folder: 'SalesLine',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 131, name: 'Posted Sales Shpt. Subform' }
+        ]
+    },
+    {
+        table: 'Sales Invoice Line',
+		folder: 'SalesLine',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 133, name: 'Posted Sales Invoice Subform' },
+            { id: 526, name: 'Posted Sales Invoice Lines' }
+        ]
+    },
+    {
+        table: 'Sales Cr.Memo Line',
+		folder: 'SalesLine',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 135, name: 'Posted Sales Cr. Memo Subform' },
+        ]
+    },
+    {
+        table: 'Return Receipt Line',
+		folder: 'SalesLine',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 6661, name: 'Posted Return Receipt Subform' }
+        ]
+    },
+    //#endregion
+    //#region Pages form tables related to Purchase Header
+    {
+        table: 'Purchase Header',
+		folder: 'PurchaseHeader',
         objectType: this.AlObjectTypes.pageExtension,
         objects: [
             { id: 49, name: 'Purchase Quote' },
             { id: 50, name: 'Purchase Order' },
             { id: 51, name: 'Purchase Invoice' },
             { id: 52, name: 'Purchase Credit Memo' },
-            { id: 136, name: 'Posted Purchase Receipt' },
-            { id: 138, name: 'Posted Purchase Invoice' },
-            { id: 140, name: 'Posted Purchase Credit Memo' },
-            { id: 145, name: 'Posted Purchase Receipts' },
-            { id: 146, name: 'Posted Purchase Invoices' },
-            { id: 147, name: 'Posted Purchase Credit Memos' },
             { id: 6640, name: 'Purchase Return Order' },
-            { id: 6660, name: 'Posted Return Receipt' },
             { id: 9306, name: 'Purchase Quotes' },
             { id: 9307, name: 'Purchase List' },
             { id: 9308, name: 'Purchase Invoices' },
@@ -145,17 +258,87 @@ exports.RelatedTables = [
         ]
     },
     {
-        folder: 'Contact',
+        table: 'Purch. Rcpt. Header',
+		folder: 'PurchaseHeader',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 145, name: 'Posted Purchase Receipts' },
+            { id: 6660, name: 'Posted Return Receipt' }
+        ]
+    },
+    {
+        table: 'Purch. Inv. Header',
+		folder: 'PurchaseHeader',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 138, name: 'Posted Purchase Invoice' },
+            { id: 146, name: 'Posted Purchase Invoices' }
+        ]
+    },
+    {
+        table: 'Purch. Cr. Memo Hdr.',
+		folder: 'PurchaseHeader',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 140, name: 'Posted Purchase Credit Memo' },
+            { id: 147, name: 'Posted Purchase Credit Memos' }
+        ]
+    },
+    {
+        table: 'Return Shipment Header',
+		folder: 'PurchaseHeader',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 6650, name: 'Posted Return Shipment' },
+            { id: 6650, name: 'Posted Return Shipments' }
+        ]
+    },
+    //#endregion
+    //#region Pages form tables related to Purchase Line
+    {
+        table: 'Purchase Line',
+		folder: 'PurchaseLine',
         objectType: this.AlObjectTypes.pageExtension,
         objects: [
             { id: 54, name: 'Purchase Order Subform' },
             { id: 55, name: 'Purch. Invoice Subform' },
             { id: 97, name: 'Purchase Quote Subform' },
             { id: 98, name: 'Purch. Cr. Memo Subform' },
-            { id: 137, name: 'Posted Purchase Rcpt. Subform' },
-            { id: 139, name: 'Posted Purch. Invoice Subform' },
-            { id: 141, name: 'Posted Purch. Cr. Memo Subform' },
             { id: 6641, name: 'Purchase Return Order Subform' }
         ]
+    },
+    {
+        table: 'Purch. Rcpt. Line',
+		folder: 'PurchaseLine',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 137, name: 'Posted Purchase Rcpt. Subform' }
+        ]
+    },
+    {
+        table: 'Purch. Inv. Line',
+		folder: 'PurchaseLine',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 139, name: 'Posted Purch. Invoice Subform' }
+        ]
+    },
+    {
+        table: 'Purch. Cr. Memo Line',
+		folder: 'PurchaseLine',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 141, name: 'Posted Purch. Cr. Memo Subform' }
+        ]
+    },
+    {
+        table: 'Return Shipment Line',
+		folder: 'PurchaseLine',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 6651, name: 'Posted Return Shipment Subform' },
+            { id: 6653, name: 'Posted Return Shipment Lines' }
+        ]
     }
+    //#endregion
 ];

--- a/relatedTables/constants.js
+++ b/relatedTables/constants.js
@@ -10,3 +10,152 @@ exports.AlObjectTypes = {
     profile: 'profile',
     XMLPort: 'xmlport'
 }
+
+exports.RelatedTables = [
+    {
+        folder: 'Contact',
+        objectType: this.AlObjectTypes.tableExtension,
+        objects: [
+            { id: 18, name: 'Customer' },
+            { id: 23, name: 'Vendor' },
+            { id: 270, name: 'Bank Account' },
+            { id: 5050, name: 'Contact' }
+        ]
+    },
+    {
+        folder: 'SalesHeader',
+        objectType: this.AlObjectTypes.tableExtension,
+        objects: [
+            { id: 36, name: 'Sales Header' },
+            { id: 110, name: 'Sales Shipment Header' },
+            { id: 112, name: 'Sales Invoice Header' },
+            { id: 114, name: 'Sales Cr.Memo Header' },
+            { id: 5107, name: 'Sales Header Archive' },
+            { id: 6660, name: 'Return Receipt Header' }
+        ]
+    },
+    {
+        folder: 'SalesLine',
+        objectType: this.AlObjectTypes.tableExtension,
+        objects: [
+            { id: 37, name: 'Sales Line' },
+            { id: 111, name: 'Sales Shipment Line' },
+            { id: 113, name: 'Sales Invoice Line' },
+            { id: 115, name: 'Sales Cr.Memo Line' },
+            { id: 5108, name: 'Sales Line Archive' },
+            { id: 6661, name: 'Return Receipt Line' }
+        ]
+    },
+    {
+        folder: 'PurchaseHeader',
+        objectType: this.AlObjectTypes.tableExtension,
+        objects: [
+            { id: 38, name: 'Purchase Header' },
+            { id: 120, name: 'Purch. Rcpt. Header' },
+            { id: 122, name: 'Purch. Inv. Header' },
+            { id: 124, name: 'Purch. Cr. Memo Hdr.' },
+            { id: 5109, name: 'Purchase Header Archive' },
+            { id: 6650, name: 'Return Shipment Header' }
+        ]
+    },
+    {
+        folder: 'PurchaseLine',
+        objectType: this.AlObjectTypes.tableExtension,
+        objects: [
+            { id: 39, name: 'Purchase Line' },
+            { id: 121, name: 'Purch. Rcpt. Line' },
+            { id: 123, name: 'Purch. Inv. Line' },
+            { id: 125, name: 'Purch. Cr. Memo Line' },
+            { id: 5110, name: 'Purchase Line Archive' },
+            { id: 6651, name: 'Return Shipment Line' }
+        ]
+    },
+    {
+        folder: 'Contact',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 21, name: 'Customer Card' },
+            { id: 22, name: 'Customer List' },
+            { id: 26, name: 'Vendor Card' },
+            { id: 27, name: 'Vendor List' },
+            { id: 370, name: 'Bank Account Card' },
+            { id: 371, name: 'Bank Account List' },
+            { id: 5050, name: 'Contact Card' },
+            { id: 5052, name: 'Contact List' }
+        ]
+    },
+    {
+        folder: 'SalesHeader',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 41, name: 'Sales Quote' },
+            { id: 42, name: 'Sales Order' },
+            { id: 43, name: 'Sales Invoice' },
+            { id: 44, name: 'Sales Credit Memo' },
+            { id: 130, name: 'Posted Sales Shipment' },
+            { id: 132, name: 'Posted Sales Invoice' },
+            { id: 134, name: 'Posted Sales Credit Memo' },
+            { id: 143, name: 'Posted Sales Invoices' },
+            { id: 144, name: 'Posted Sales Credit Memos' },
+            { id: 6630, name: 'Sales Return Order' },
+            { id: 9300, name: 'Sales Quotes' },
+            { id: 9301, name: 'Sales Invoice List' },
+            { id: 9302, name: 'Sales Credit Memos' },
+            { id: 9304, name: 'Sales Return Order List' },
+            { id: 9305, name: 'Sales Order List' }
+        ]
+    },
+    {
+        folder: 'SalesLine',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 46, name: 'Sales Order Subform' },
+            { id: 47, name: 'Sales Invoice Subform' },
+            { id: 95, name: 'Sales Quote Subform' },
+            { id: 96, name: 'Sales Cr. Memo Subform' },
+            { id: 131, name: 'Posted Sales Shpt. Subform' },
+            { id: 133, name: 'Posted Sales Invoice Subform' },
+            { id: 135, name: 'Posted Sales Cr. Memo Subform' },
+            { id: 516, name: 'Sales Lines' },
+            { id: 526, name: 'Posted Sales Invoice Lines' },
+            { id: 6631, name: 'Sales Return Order Subform' }
+        ]
+    },
+    {
+        folder: 'PurchaseHeader',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 49, name: 'Purchase Quote' },
+            { id: 50, name: 'Purchase Order' },
+            { id: 51, name: 'Purchase Invoice' },
+            { id: 52, name: 'Purchase Credit Memo' },
+            { id: 136, name: 'Posted Purchase Receipt' },
+            { id: 138, name: 'Posted Purchase Invoice' },
+            { id: 140, name: 'Posted Purchase Credit Memo' },
+            { id: 145, name: 'Posted Purchase Receipts' },
+            { id: 146, name: 'Posted Purchase Invoices' },
+            { id: 147, name: 'Posted Purchase Credit Memos' },
+            { id: 6640, name: 'Purchase Return Order' },
+            { id: 6660, name: 'Posted Return Receipt' },
+            { id: 9306, name: 'Purchase Quotes' },
+            { id: 9307, name: 'Purchase List' },
+            { id: 9308, name: 'Purchase Invoices' },
+            { id: 9309, name: 'Purchase Credit Memos' },
+            { id: 9311, name: 'Purchase Return Order List' }
+        ]
+    },
+    {
+        folder: 'Contact',
+        objectType: this.AlObjectTypes.pageExtension,
+        objects: [
+            { id: 54, name: 'Purchase Order Subform' },
+            { id: 55, name: 'Purch. Invoice Subform' },
+            { id: 97, name: 'Purchase Quote Subform' },
+            { id: 98, name: 'Purch. Cr. Memo Subform' },
+            { id: 137, name: 'Posted Purchase Rcpt. Subform' },
+            { id: 139, name: 'Posted Purch. Invoice Subform' },
+            { id: 141, name: 'Posted Purch. Cr. Memo Subform' },
+            { id: 6641, name: 'Purchase Return Order Subform' }
+        ]
+    }
+];

--- a/relatedTables/fileManagement.js
+++ b/relatedTables/fileManagement.js
@@ -21,8 +21,7 @@ function createAlFile(destinationPath, objectType, objectId, objectName){
     {
 
     }
-}
-        `;
+}`;
             break;
         case constants.AlObjectTypes.pageExtension:
             fileName = 'Pag';
@@ -36,10 +35,10 @@ function createAlFile(destinationPath, objectType, objectId, objectName){
     actions
     {
     }
-}
-        `;
+}`;
             break;
         default:
+            console.error('Unsuported AL object type.');
             throw Error('Unsuported AL object type.');
     }
     

--- a/relatedTables/fileManagement.js
+++ b/relatedTables/fileManagement.js
@@ -1,0 +1,130 @@
+const path = require("path");
+const fs = require("fs");
+const vscode = require('vscode');
+const constants = require("./constants");
+
+//#region AL File Creation
+function createAlFile(destinationPath, objectType, objectId, objectName){
+    const newObjectId = objectId + 80000;
+    let newObjectName = objectName.replace(/\s/g,'');
+    newObjectName = newObjectName.replace('.', '');
+    let fileName;
+    let fileContent;
+    // Generate File Name and Content
+    switch (objectType) {
+        case constants.AlObjectTypes.tableExtension:
+            fileName = 'Tab';
+            fileContent = 
+        `
+{
+    fields
+    {
+
+    }
+}
+        `;
+            break;
+        case constants.AlObjectTypes.pageExtension:
+            fileName = 'Pag';
+            fileContent = 
+        `
+{
+    layout
+    {
+    }
+
+    actions
+    {
+    }
+}
+        `;
+            break;
+        default:
+            throw Error('Unsuported AL object type.');
+    }
+    
+    fileName = fileName + objectId + '-' + 'Ext' + newObjectId + '.' + newObjectName + '.al';
+    //vscode.window.showInformationMessage(fileName);
+    //Generate Path
+    const filePath = path.join(destinationPath, fileName);
+    return existsFileAsync(filePath)
+            .then(exists => {
+            if (exists) {
+                return filePath;
+            }
+            const contents = objectType + ' ' + newObjectId + ' "' + newObjectName + '" extends "' +  objectName + '" //' + objectId + fileContent;
+            return writeTextFileAsync(filePath, contents)
+                .then(() => filePath);
+            });  
+}
+exports.createAlFile = createAlFile;
+//#endregion
+
+//#region File Creation
+function writeTextFileAsync(filename, data) {
+    return new Promise((resolve, reject) => {
+        fs.writeFile(filename, data, { encoding: "utf-8" }, e => {
+            if (e) {
+                return reject(e);
+            }
+            resolve(true);
+        });
+    });
+}
+function existsFileAsync(filename) {
+    return new Promise(resolve => {
+        fs.exists(filename, exists => {
+            resolve(exists);
+        });
+    });
+}
+//#endregion
+
+//#region Workspace Finder
+function getCurrentWorkspaceFolderPath() {
+    const currentWorkspaceFolder = getCurrentWorkspaceFolder();
+    if (currentWorkspaceFolder) {
+        return currentWorkspaceFolder.uri.fsPath;
+    }
+    return undefined;
+}
+exports.getCurrentWorkspaceFolderPath = getCurrentWorkspaceFolderPath;
+
+function getCurrentWorkspaceFolder() {
+    const activeEditor = vscode.window.activeTextEditor;
+    if (activeEditor) {
+        if (activeEditor.document) {
+            lastActiveWorkspace = getWorkspaceFolderFromPath(activeEditor.document.fileName);
+            return lastActiveWorkspace;
+        }
+    }
+}
+
+function getWorkspaceFolderFromPath(path) {
+    if (!Array.isArray(vscode.workspace.workspaceFolders) || vscode.workspace.workspaceFolders.length === 0) {
+        lastActiveWorkspace = undefined;
+        return lastActiveWorkspace;
+    }
+    // one workspace folder, this is the old folder/rootpath scenario.
+    if (vscode.workspace.workspaceFolders.length === 1) {
+        lastActiveWorkspace = vscode.workspace.workspaceFolders[0];
+        return lastActiveWorkspace;
+    }
+    const uri = vscode.Uri.file(path);
+    const workspace = vscode.workspace.getWorkspaceFolder(uri);
+    return workspace;
+}
+//#endregion
+
+//#region Folder Creation
+function createFolder(dir) {
+    if (fs.existsSync(dir)) return;
+    if (!fs.existsSync(path.dirname(dir))) {
+        this.makeDirSync(path.dirname(dir));
+    }
+    fs.mkdirSync(dir);
+}
+exports.createFolder = createFolder;
+//#endregion
+
+let lastActiveWorkspace = undefined;

--- a/relatedTables/fileManagement.js
+++ b/relatedTables/fileManagement.js
@@ -4,10 +4,9 @@ const vscode = require('vscode');
 const constants = require("./constants");
 
 //#region AL File Creation
-function createAlFile(destinationPath, objectType, objectId, objectName){
+function createAlFile(destinationPath, objectType, objectId, objectName, objectNamePrefix){
     const newObjectId = objectId + 80000;
-    let newObjectName = objectName.replace(/\s/g,'');
-    newObjectName = newObjectName.replace('.', '');
+    let newObjectName = objectName.replace(/[^\w]/g,'');
     let fileName;
     let fileContent;
     // Generate File Name and Content
@@ -51,7 +50,7 @@ function createAlFile(destinationPath, objectType, objectId, objectName){
             if (exists) {
                 return filePath;
             }
-            const contents = objectType + ' ' + newObjectId + ' "' + newObjectName + '" extends "' +  objectName + '" //' + objectId + fileContent;
+            const contents = objectType + ' ' + newObjectId + ' "' + objectNamePrefix + newObjectName + '" extends "' +  objectName + '" //' + objectId + fileContent;
             return writeTextFileAsync(filePath, contents)
                 .then(() => filePath);
             });  

--- a/relatedTables/relatedTables.js
+++ b/relatedTables/relatedTables.js
@@ -44,18 +44,34 @@ exports.RelatedTablesManager = class RelatedTablesManager {
         this.tableToRelatedObjects = new Map();
         this.pageToRelatedTable = new Map();
         constants.RelatedTables.forEach(element => {
-            element.objects.forEach(object => {
-                if (!this.tableToRelatedObjects.has(element.table))
-                this.tableToRelatedObjects.set(element.table, new Map());
-                if (!this.tableToRelatedObjects.get(element.table).has(element.objectType))
-                this.tableToRelatedObjects.get(element.table).set(element.objectType, []);
-
-                this.tableToRelatedObjects.get(element.table).get(element.objectType).push(object.name);
-
-                if (element.objectType === constants.AlObjectTypes.pageExtension) {
+            if (element.objectType === constants.AlObjectTypes.tableExtension) {
+                element.objects.forEach(object1 => {
+                    if (!this.tableToRelatedObjects.has(object1.name)) {
+                        this.tableToRelatedObjects.set(object1.name, {
+                            [constants.AlObjectTypes.tableExtension]: [],
+                            [constants.AlObjectTypes.pageExtension]: []
+                        });
+                    }
+                    element.objects.forEach(object2 => {
+                        if (object1.name !== object2.name) {
+                            this.tableToRelatedObjects.get(object1.name)
+                                [constants.AlObjectTypes.tableExtension].push(object2.name);
+                        }
+                    });
+                });
+            } else if (element.objectType === constants.AlObjectTypes.pageExtension) {
+                element.objects.forEach(object => {
+                    if (!this.tableToRelatedObjects.has(element.table)) {
+                        this.tableToRelatedObjects.set(element.table, {
+                            [constants.AlObjectTypes.tableExtension]: [],
+                            [constants.AlObjectTypes.pageExtension]: []
+                        });
+                    }
+                    this.tableToRelatedObjects.get(element.table)
+                        [constants.AlObjectTypes.pageExtension].push(object.name);
                     this.pageToRelatedTable.set(object.name, element.table);
-                }
-            });
+                });
+            }
         });
     }
 
@@ -108,8 +124,8 @@ exports.RelatedTablesManager = class RelatedTablesManager {
         const relatedObjects = [];
         if (sourceAlObjectType === constants.AlObjectTypes.tableExtension) {
             alObjectTypesToOpen.forEach(alObjectType => {
-                if (this.tableToRelatedObjects.has(objectName) && this.tableToRelatedObjects.get(objectName).has(alObjectType)) {
-                    this.tableToRelatedObjects.get(objectName).get(alObjectType).forEach(
+                if (this.tableToRelatedObjects.has(objectName)) {
+                    this.tableToRelatedObjects.get(objectName)[alObjectType].forEach(
                         objectName => relatedObjects.push({name: objectName, type: alObjectType})
                     );
                 }

--- a/relatedTables/relatedTables.js
+++ b/relatedTables/relatedTables.js
@@ -5,7 +5,7 @@ const fileMangagement = require('./fileManagement');
 /**
  * @returns {Promise}
  */
-exports.createRelatedTables = (objectNamePrefix) => {
+exports.createRelatedTables = function createRelatedTables(objectNamePrefix) {
     const rootPath = fileMangagement.getCurrentWorkspaceFolderPath();
     // if rootpath is empty then error
     if (!rootPath) {
@@ -30,3 +30,118 @@ exports.createRelatedTables = (objectNamePrefix) => {
 
     return Promise.all(fileCreationPromises);
 }
+
+
+exports.RelatedTablesManager = class RelatedTablesManager {
+    tableToRelatedObjects;
+    pageToRelatedTable;
+
+    constructor() {
+        this.setTableAndPageToRelatedObjects();
+    }
+
+    setTableAndPageToRelatedObjects() {
+        this.tableToRelatedObjects = new Map();
+        this.pageToRelatedTable = new Map();
+        constants.RelatedTables.forEach(element => {
+            element.objects.forEach(object => {
+                if (!this.tableToRelatedObjects.has(element.table))
+                this.tableToRelatedObjects.set(element.table, new Map());
+                if (!this.tableToRelatedObjects.get(element.table).has(element.objectType))
+                this.tableToRelatedObjects.get(element.table).set(element.objectType, []);
+
+                this.tableToRelatedObjects.get(element.table).get(element.objectType).push(object.name);
+
+                if (element.objectType === constants.AlObjectTypes.pageExtension) {
+                    this.pageToRelatedTable.set(object.name, element.table);
+                }
+            });
+        });
+    }
+
+    //#region Open related objects
+    /**
+     * @param {string} objectName
+     * @returns {boolean} Found related tables
+     */
+    openRelateTables(objectName, sourceAlObjectType) {
+        return this.openRelateObjects(objectName, sourceAlObjectType, [constants.AlObjectTypes.tableExtension]);
+    }
+    
+    /**
+     * @param {string} objectName
+     * @returns {boolean} Found related pages
+     */
+    openRelatePages(objectName, sourceAlObjectType) {
+        return this.openRelateObjects(objectName, sourceAlObjectType, [constants.AlObjectTypes.pageExtension]);
+    }
+    
+    /**
+     * @param {string} objectName
+     * @returns {boolean} Found related tables and/or pages
+     */
+    openRelatePagesAndTables(objectName, sourceAlObjectType) {
+        return this.openRelateObjects(objectName, sourceAlObjectType, [constants.AlObjectTypes.tableExtension, constants.AlObjectTypes.pageExtension]);
+    }
+    //#endregion
+
+    /**
+     * Opens all related objects of 'objectName' that are Sof a object type in the 'alObjectTypes' array
+     * @param {string} objectName
+     * @param {string[]} alObjectTypes
+     * @returns {boolean} Found related objects
+     */
+    openRelateObjects(objectName, sourceAlObjectType, alObjectTypes) {
+        const relatedObjects = this.getRelateObjects(objectName, sourceAlObjectType, alObjectTypes);
+        relatedObjects.forEach(relatedObject =>
+            fileMangagement.openALFile(relatedObject.name, relatedObject.type)
+        );
+        return relatedObjects.length > 0;
+    }
+
+    /**
+     * @param {string} objectName
+     * @param {string[]} alObjectTypesToOpen
+     * @returns {{name: string, type: string}[]} Related AL objects
+     */
+    getRelateObjects(objectName, sourceAlObjectType, alObjectTypesToOpen){
+        const relatedObjects = [];
+        if (sourceAlObjectType === constants.AlObjectTypes.tableExtension) {
+            alObjectTypesToOpen.forEach(alObjectType => {
+                if (this.tableToRelatedObjects.has(objectName) && this.tableToRelatedObjects.get(objectName).has(alObjectType)) {
+                    this.tableToRelatedObjects.get(objectName).get(alObjectType).forEach(
+                        objectName => relatedObjects.push({name: objectName, type: alObjectType})
+                    );
+                }
+            });
+        } else if (sourceAlObjectType === constants.AlObjectTypes.pageExtension) { 
+            const relatedTableName = this.pageToRelatedTable.get(objectName);
+            if (alObjectTypesToOpen.includes(constants.AlObjectTypes.tableExtension)){
+                relatedObjects.push({name: relatedTableName, type: constants.AlObjectTypes.tableExtension});
+            }
+            if (alObjectTypesToOpen.includes(constants.AlObjectTypes.pageExtension)) {
+                this.getRelateObjects(relatedTableName, constants.AlObjectTypes.tableExtension, alObjectTypesToOpen).forEach(relatedObject => {
+                    if (relatedObject.name !== objectName)
+                        relatedObjects.push(relatedObject);
+                });
+            }
+        }
+        return relatedObjects;
+    }
+}
+
+//#region getExtensionObjectInfo
+const extensionObjectRegex = /^\s*(?<alObjectType>(page|table)extension)\s+(?<objectId>\d+)\s+(?<extensionName>\w+|"[^"]*")\s+extends\s+(?<exendedObjectName>\w+|"[^"]*")(\s*\/\/\s*(?<exendedObjectId>\d+))?/m;
+/**
+ * Only works for extension objects
+ * @param {vscode.TextDocument} document
+ * @returns {{[key: string]: string}} Has keys: alObjectType, objectId, extensionName, exendedObjectName, and possibly exendedObjectId
+ */
+exports.getExtensionObjectInfo = function getExtensionObjectInfo(document){
+    const match = extensionObjectRegex.exec(document.getText());
+    if (match === null) return undefined;
+    match.groups.extensionName = match.groups.extensionName.replace(/"/g, '');
+    match.groups.exendedObjectName = match.groups.exendedObjectName.replace(/"/g, '');
+    return match.groups;
+}
+//#endregion

--- a/relatedTables/relatedTables.js
+++ b/relatedTables/relatedTables.js
@@ -1,10 +1,11 @@
+const vscode = require('vscode');
 const constants = require('./constants');
 const fileMangagement = require('./fileManagement');
 
 /**
  * @returns {Promise}
  */
-exports.createRelatedTables = () => {
+exports.createRelatedTables = (objectNamePrefix) => {
     const rootPath = fileMangagement.getCurrentWorkspaceFolderPath();
     // if rootpath is empty then error
     if (!rootPath) {
@@ -23,7 +24,7 @@ exports.createRelatedTables = () => {
         fileMangagement.createFolder(destinationPath);
 
         element.objects.forEach(object => {
-            fileCreationPromises.push(fileMangagement.createAlFile(destinationPath, element.objectType, object.id, object.name));
+            fileCreationPromises.push(fileMangagement.createAlFile(destinationPath, element.objectType, object.id, object.name, objectNamePrefix));
         });
     });
 

--- a/relatedTables/relatedTables.js
+++ b/relatedTables/relatedTables.js
@@ -5,143 +5,27 @@ const fileMangagement = require('./fileManagement');
  * @returns {Promise}
  */
 exports.createRelatedTables = () => {
-    // The code you place here will be executed every time your command is executed
     const rootPath = fileMangagement.getCurrentWorkspaceFolderPath();
-    //vscode.window.showInformationMessage(rootPath);
     // if rootpath is empty then error
     if (!rootPath) {
         return Promise.reject("No AL workspace folder is active");
     }
 
-    // tableextensions
-    //vscode.window.showInformationMessage(rootPath);
     const baseDestinationPath = rootPath + '/src/';
-    //vscode.window.showInformationMessage(rootPath);
-    
-    //Create Table Extension Folder
-    let destinationPath = baseDestinationPath + constants.AlObjectTypes.tableExtension + '/';
-    fileMangagement.createFolder(destinationPath);
-    //Contact
-    destinationPath = destinationPath + 'Contact/'
-    fileMangagement.createFolder(destinationPath);
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 18, 'Customer');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 23, 'Vendor');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 270, 'Bank Account');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 5050, 'Contact');
-    //SalesHeader
-    destinationPath = baseDestinationPath + constants.AlObjectTypes.tableExtension + '/SalesHeader/';
-    fileMangagement.createFolder(destinationPath);
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 36, 'Sales Header');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 110, 'Sales Shipment Header');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 112, 'Sales Invoice Header');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 114, 'Sales Cr.Memo Header');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 5107, 'Sales Header Archive');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 6660, 'Return Receipt Header');
-    //SalesLine
-    destinationPath = baseDestinationPath + constants.AlObjectTypes.tableExtension + '/SalesLine/';
-    fileMangagement.createFolder(destinationPath);
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 37, 'Sales Line');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 111, 'Sales Shipment Line');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 113, 'Sales Invoice Line');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 115, 'Sales Cr.Memo Line');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 5108, 'Sales Line Archive');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 6661, 'Return Receipt Line');
-    //PurchaseHeader
-    destinationPath = baseDestinationPath + constants.AlObjectTypes.tableExtension + '/PurchaseHeader/';
-    fileMangagement.createFolder(destinationPath);
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 38, 'Purchase Header');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 120, 'Purch. Rcpt. Header');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 122, 'Purch. Inv. Header');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 124, 'Purch. Cr. Memo Hdr.');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 5109, 'Purchase Header Archive');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 6650, 'Return Shipment Header');
-    //PurchaseLine
-    destinationPath = baseDestinationPath + constants.AlObjectTypes.tableExtension + '/PurchaseLine/';
-    fileMangagement.createFolder(destinationPath);
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 39, 'Purchase Line');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 121, 'Purch. Rcpt. Line');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 123, 'Purch. Inv. Line');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 125, 'Purch. Cr. Memo Line');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 5110, 'Purchase Line Archive');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 6651, 'Return Shipment Line');
+    fileMangagement.createFolder(baseDestinationPath);
 
-    // pageextensions
-    //Create Page Extension Folder
-    destinationPath = baseDestinationPath + constants.AlObjectTypes.pageExtension + '/';
-    fileMangagement.createFolder(destinationPath);
-    //Contact
-    destinationPath = destinationPath + 'Contact/'
-    fileMangagement.createFolder(destinationPath);
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 21, 'Customer Card');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 22, 'Customer List');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 26, 'Vendor Card');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 27, 'Vendor List');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 370, 'Bank Account Card');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 371, 'Bank Account List');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 5050, 'Contact Card');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 5052, 'Contact List');
-    //SalesHeader
-    destinationPath = baseDestinationPath + constants.AlObjectTypes.pageExtension + '/SalesHeader/';
-    fileMangagement.createFolder(destinationPath);
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 41, 'Sales Quote');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 42, 'Sales Order');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 43, 'Sales Invoice');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 44, 'Sales Credit Memo');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 130, 'Posted Sales Shipment');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 132, 'Posted Sales Invoice');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 134, 'Posted Sales Credit Memo');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 143, 'Posted Sales Invoices');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 144, 'Posted Sales Credit Memos');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 6630, 'Sales Return Order');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9300, 'Sales Quotes');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9301, 'Sales Invoice List');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9302, 'Sales Credit Memos');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9304, 'Sales Return Order List');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9305, 'Sales Order List');
-    //SalesLine
-    destinationPath = baseDestinationPath + constants.AlObjectTypes.pageExtension + '/SalesLine/';
-    fileMangagement.createFolder(destinationPath);
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 46, 'Sales Order Subform');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 47, 'Sales Invoice Subform');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 95, 'Sales Quote Subform');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 96, 'Sales Cr. Memo Subform');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 131, 'Posted Sales Shpt. Subform');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 133, 'Posted Sales Invoice Subform');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 135, 'Posted Sales Cr. Memo Subform');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 516, 'Sales Lines');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 526, 'Posted Sales Invoice Lines');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 6631, 'Sales Return Order Subform');
-    //PurchaseHeader
-    destinationPath = baseDestinationPath + constants.AlObjectTypes.pageExtension + '/PurchaseHeader/';
-    fileMangagement.createFolder(destinationPath);
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 49, 'Purchase Quote');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 50, 'Purchase Order');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 51, 'Purchase Invoice');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 52, 'Purchase Credit Memo');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 136, 'Posted Purchase Receipt');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 138, 'Posted Purchase Invoice');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 140, 'Posted Purchase Credit Memo');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 145, 'Posted Purchase Receipts');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 146, 'Posted Purchase Invoices');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 147, 'Posted Purchase Credit Memos');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 6640, 'Purchase Return Order');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 6660, 'Posted Return Receipt');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9306, 'Purchase Quotes');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9307, 'Purchase List');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9308, 'Purchase Invoices');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9309, 'Purchase Credit Memos');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9311, 'Purchase Return Order List');
-    //PurchaseLine
-    destinationPath = baseDestinationPath + constants.AlObjectTypes.pageExtension + '/PurchaseLine/';
-    fileMangagement.createFolder(destinationPath);
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 54, 'Purchase Order Subform');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 55, 'Purch. Invoice Subform');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 97, 'Purchase Quote Subform');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 98, 'Purch. Cr. Memo Subform');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 137, 'Posted Purchase Rcpt. Subform');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 139, 'Posted Purch. Invoice Subform');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 141, 'Posted Purch. Cr. Memo Subform');
-    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 6641, 'Purchase Return Order Subform');
+    let destinationPath;
+    const fileCreationPromises = [];
+    constants.RelatedTables.forEach(element => {
+        destinationPath = baseDestinationPath + element.objectType;
+        fileMangagement.createFolder(destinationPath);
+        destinationPath += '/' + element.folder
+        fileMangagement.createFolder(destinationPath);
 
-    return Promise.resolve();
+        element.objects.forEach(object => {
+            fileCreationPromises.push(fileMangagement.createAlFile(destinationPath, element.objectType, object.id, object.name));
+        });
+    });
+
+    return Promise.all(fileCreationPromises);
 }

--- a/relatedTables/relatedTables.js
+++ b/relatedTables/relatedTables.js
@@ -1,0 +1,147 @@
+const constants = require('./constants');
+const fileMangagement = require('./fileManagement');
+
+/**
+ * @returns {Promise}
+ */
+exports.createRelatedTables = () => {
+    // The code you place here will be executed every time your command is executed
+    const rootPath = fileMangagement.getCurrentWorkspaceFolderPath();
+    //vscode.window.showInformationMessage(rootPath);
+    // if rootpath is empty then error
+    if (!rootPath) {
+        return Promise.reject("No AL workspace folder is active");
+    }
+
+    // tableextensions
+    //vscode.window.showInformationMessage(rootPath);
+    const baseDestinationPath = rootPath + '/src/';
+    //vscode.window.showInformationMessage(rootPath);
+    
+    //Create Table Extension Folder
+    let destinationPath = baseDestinationPath + constants.AlObjectTypes.tableExtension + '/';
+    fileMangagement.createFolder(destinationPath);
+    //Contact
+    destinationPath = destinationPath + 'Contact/'
+    fileMangagement.createFolder(destinationPath);
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 18, 'Customer');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 23, 'Vendor');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 270, 'Bank Account');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 5050, 'Contact');
+    //SalesHeader
+    destinationPath = baseDestinationPath + constants.AlObjectTypes.tableExtension + '/SalesHeader/';
+    fileMangagement.createFolder(destinationPath);
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 36, 'Sales Header');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 110, 'Sales Shipment Header');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 112, 'Sales Invoice Header');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 114, 'Sales Cr.Memo Header');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 5107, 'Sales Header Archive');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 6660, 'Return Receipt Header');
+    //SalesLine
+    destinationPath = baseDestinationPath + constants.AlObjectTypes.tableExtension + '/SalesLine/';
+    fileMangagement.createFolder(destinationPath);
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 37, 'Sales Line');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 111, 'Sales Shipment Line');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 113, 'Sales Invoice Line');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 115, 'Sales Cr.Memo Line');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 5108, 'Sales Line Archive');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 6661, 'Return Receipt Line');
+    //PurchaseHeader
+    destinationPath = baseDestinationPath + constants.AlObjectTypes.tableExtension + '/PurchaseHeader/';
+    fileMangagement.createFolder(destinationPath);
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 38, 'Purchase Header');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 120, 'Purch. Rcpt. Header');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 122, 'Purch. Inv. Header');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 124, 'Purch. Cr. Memo Hdr.');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 5109, 'Purchase Header Archive');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 6650, 'Return Shipment Header');
+    //PurchaseLine
+    destinationPath = baseDestinationPath + constants.AlObjectTypes.tableExtension + '/PurchaseLine/';
+    fileMangagement.createFolder(destinationPath);
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 39, 'Purchase Line');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 121, 'Purch. Rcpt. Line');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 123, 'Purch. Inv. Line');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 125, 'Purch. Cr. Memo Line');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 5110, 'Purchase Line Archive');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.tableExtension, 6651, 'Return Shipment Line');
+
+    // pageextensions
+    //Create Page Extension Folder
+    destinationPath = baseDestinationPath + constants.AlObjectTypes.pageExtension + '/';
+    fileMangagement.createFolder(destinationPath);
+    //Contact
+    destinationPath = destinationPath + 'Contact/'
+    fileMangagement.createFolder(destinationPath);
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 21, 'Customer Card');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 22, 'Customer List');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 26, 'Vendor Card');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 27, 'Vendor List');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 370, 'Bank Account Card');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 371, 'Bank Account List');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 5050, 'Contact Card');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 5052, 'Contact List');
+    //SalesHeader
+    destinationPath = baseDestinationPath + constants.AlObjectTypes.pageExtension + '/SalesHeader/';
+    fileMangagement.createFolder(destinationPath);
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 41, 'Sales Quote');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 42, 'Sales Order');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 43, 'Sales Invoice');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 44, 'Sales Credit Memo');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 130, 'Posted Sales Shipment');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 132, 'Posted Sales Invoice');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 134, 'Posted Sales Credit Memo');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 143, 'Posted Sales Invoices');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 144, 'Posted Sales Credit Memos');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 6630, 'Sales Return Order');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9300, 'Sales Quotes');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9301, 'Sales Invoice List');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9302, 'Sales Credit Memos');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9304, 'Sales Return Order List');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9305, 'Sales Order List');
+    //SalesLine
+    destinationPath = baseDestinationPath + constants.AlObjectTypes.pageExtension + '/SalesLine/';
+    fileMangagement.createFolder(destinationPath);
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 46, 'Sales Order Subform');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 47, 'Sales Invoice Subform');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 95, 'Sales Quote Subform');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 96, 'Sales Cr. Memo Subform');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 131, 'Posted Sales Shpt. Subform');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 133, 'Posted Sales Invoice Subform');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 135, 'Posted Sales Cr. Memo Subform');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 516, 'Sales Lines');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 526, 'Posted Sales Invoice Lines');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 6631, 'Sales Return Order Subform');
+    //PurchaseHeader
+    destinationPath = baseDestinationPath + constants.AlObjectTypes.pageExtension + '/PurchaseHeader/';
+    fileMangagement.createFolder(destinationPath);
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 49, 'Purchase Quote');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 50, 'Purchase Order');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 51, 'Purchase Invoice');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 52, 'Purchase Credit Memo');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 136, 'Posted Purchase Receipt');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 138, 'Posted Purchase Invoice');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 140, 'Posted Purchase Credit Memo');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 145, 'Posted Purchase Receipts');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 146, 'Posted Purchase Invoices');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 147, 'Posted Purchase Credit Memos');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 6640, 'Purchase Return Order');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 6660, 'Posted Return Receipt');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9306, 'Purchase Quotes');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9307, 'Purchase List');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9308, 'Purchase Invoices');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9309, 'Purchase Credit Memos');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 9311, 'Purchase Return Order List');
+    //PurchaseLine
+    destinationPath = baseDestinationPath + constants.AlObjectTypes.pageExtension + '/PurchaseLine/';
+    fileMangagement.createFolder(destinationPath);
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 54, 'Purchase Order Subform');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 55, 'Purch. Invoice Subform');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 97, 'Purchase Quote Subform');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 98, 'Purch. Cr. Memo Subform');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 137, 'Posted Purchase Rcpt. Subform');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 139, 'Posted Purch. Invoice Subform');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 141, 'Posted Purch. Cr. Memo Subform');
+    fileMangagement.createAlFile(destinationPath, constants.AlObjectTypes.pageExtension, 6641, 'Purchase Return Order Subform');
+
+    return Promise.resolve();
+}


### PR DESCRIPTION
- Moved code for _ALTB: Start Project: Create Related Tables_ to _relatedTables_ folder.
- Added declaration of all related tables and their pages to _relatedTables/constants_.
- Added prefix to the created object names. This prefix is taken from the vscode-settings _alVarHelper.ignoreALPrefix_ or _CRS.ObjectNamePrefix_. If these are not declared a prefix is asked to the user.
- Added _ALTB: Open Related Tables_, _ALTB: Open Related Pages_, and _ALTB: Open Related Tables and Pages_