### PR TITLE
Duplicate EntityName & EntitySetName Error for API Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,15 +22,7 @@
         "Snippets"
     ],
     "activationEvents": [
-        "onCommand:al-toolbox.createRelatedTables",
-        "onCommand:al-toolbox.wrapAllFunctions",
-        "onCommand:al-toolbox.wrapAllDataItemsAndColumns",
-        "onCommand:al-toolbox.wrapAll",
-        "onCommand:al-toolbox.openRelatedTables",
-        "onCommand:al-toolbox.openRelatedPages",
-        "onCommand:al-toolbox.openRelatedTablesAndPages",
-        "onCommand:al-toolbox.renumberAll",
-        "onCommand:al-toolbox.changePrefix"
+        "onLanguage:al"
     ],
     "main": "./src/extension.js",
     "contributes": {
@@ -112,6 +104,12 @@
                         "default": true,
                         "description": "Use '<ObjectPrefix>(<ExtenedObjectId>-Ext)?<ObjectId>.<ObjectNameExcludingPrefix>.al' instead of '<ObjectNameExcludingPrefix>.<FullTypeName>(Ext)?.al' for file names",
                         "scope": "resource"
+                    },
+                    "ALTB.DisbleAPIEntityWarnings": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Disables errors for dublicate EntityName and/or EntitySetName from API pages that have the same APIPublisher, APIGroup, and APIVersion",
+                        "scope": "window"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -115,6 +115,13 @@
                         "default": false,
                         "description": "Disables errors for duplicate EntityName and/or EntitySetName from API pages that have the same APIPublisher, APIGroup, and APIVersion",
                         "scope": "window"
+                    },
+                    "ALTB.AdditionalRelatedObjects": {
+                        "type": "array",
+                        "default": [],
+                        "description":
+                            "Adds additional related pages and tables. These are used while navigating and creating related tables.\nNote that this only works for PageExtensions and TableExtensions, not your own Pages and Tables.\n\nThe syntax can be found in the AL Toolbox repository: src/constanst.js -> RelatedObjects",
+                        "scope": "resource"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "Snippets"
     ],
     "activationEvents": [
-        "onLanguage:al"
+        "onLanguage:al",
+        "onCommand:al-toolbox.createRelatedTables"
     ],
     "main": "./src/extension.js",
     "contributes": {
@@ -93,6 +94,10 @@
             {
                 "command": "al-toolbox.changePrefix",
                 "title": "ALTB: Change object prefix"
+            },
+            {
+                "command": "al-toolbox.copyFieldsToRelatedTables",
+                "title": "ALTB: Copy fields to related tables"
             }
         ],
         "configuration": [
@@ -105,7 +110,7 @@
                         "description": "Use '<ObjectPrefix>(<ExtenedObjectId>-Ext)?<ObjectId>.<ObjectNameExcludingPrefix>.al' instead of '<ObjectNameExcludingPrefix>.<FullTypeName>(Ext)?.al' for file names",
                         "scope": "resource"
                     },
-                    "ALTB.DisbleAPIEntityWarnings": {
+                    "ALTB.DisableAPIEntityWarnings": {
                         "type": "boolean",
                         "default": false,
                         "description": "Disables errors for duplicate EntityName and/or EntitySetName from API pages that have the same APIPublisher, APIGroup, and APIVersion",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
                     "ALTB.DisbleAPIEntityWarnings": {
                         "type": "boolean",
                         "default": false,
-                        "description": "Disables errors for dublicate EntityName and/or EntitySetName from API pages that have the same APIPublisher, APIGroup, and APIVersion",
+                        "description": "Disables errors for duplicate EntityName and/or EntitySetName from API pages that have the same APIPublisher, APIGroup, and APIVersion",
                         "scope": "window"
                     }
                 }

--- a/src/codeAnalyzers/apiPageEntityAnalyzer.js
+++ b/src/codeAnalyzers/apiPageEntityAnalyzer.js
@@ -1,0 +1,293 @@
+const vscode = require('vscode');
+const fileManagement = require('../fileManagement/fileManagement');
+const alFileManagement = require('../fileManagement/alFileManagement');
+const constants = require('../constants');
+
+const DuplicateEntityNameErrMsg = 'Duplicate entityName';
+const DuplicateEntitySetNameErrMsg = 'Dublicate entitySetName';
+
+const EntityType = {
+    EntityName: 'EntityName',
+    EntitySetName: 'EntitySetName',
+}
+
+const pageTypeReg = /\bPageType\s*=\s*(\w+)\s*;/i;
+const apiPublisherReg = /\bAPIPublisher\s*=\s*'([^']+)'\s*;/i;
+const apiGroupReg = /\bAPIGroup\s*=\s*'([^']+)'\s*;/i;
+const apiVersionReg = /\bAPIVersion\s*=\s*'([^']+)'\s*;/i;
+const entityNameReg = /\bEntityName\s*=\s*'([^']+)'\s*;/i;
+const entitySetNameReg = /\bEntitySetName\s*=\s*'([^']+)'\s*;/i;
+const NotAnApiPage = 'Not an API page';
+
+class ApiPageEntityInfo {
+    apiPublisher;
+    apiGroup;
+    apiVersion;
+    entityName;
+    entitySetName;
+
+    getPath() {
+        return this.fileUri.fsPath;
+    }
+    fileUri;
+    entityRange;
+    entitySetRange;
+    isAPIPage;
+
+    /**
+     * @param {vscode.TextDocument} textDocument 
+     */
+    constructor(textDocument){
+        this.initInfo(textDocument);
+    }
+    
+    /**
+     * @param {vscode.TextDocument} textDocument 
+     */
+    initInfo(textDocument) {
+        this.fileUri = textDocument.uri;
+        
+        var fileContent = textDocument.getText();
+        var match = pageTypeReg.exec(fileContent);
+        if(!match || match[1].toUpperCase() !== 'API') {
+            this.isAPIPage = false;
+            return this.isAPIPage;
+        };
+        this.isAPIPage = true;
+        
+        this.apiPublisher = apiPublisherReg.exec(fileContent)[1];
+        this.apiGroup = apiGroupReg.exec(fileContent)[1];
+        this.apiVersion = apiVersionReg.exec(fileContent)[1];
+
+        match = entityNameReg.exec(fileContent);
+        this.entityName = match[1];
+        this.entityRange = fileManagement.getMatchRange(match);
+
+        match = entitySetNameReg.exec(fileContent);
+        this.entitySetName = match[1];
+        this.entitySetRange = fileManagement.getMatchRange(match);
+        return this.isAPIPage;
+    }
+
+    asKey(type) {
+        return `${this.apiPublisher}|${this.apiGroup}|${this.apiVersion}|${
+            type === EntityType.EntityName ? this.entityName : this.entitySetName
+        }`;
+    }
+
+    getAsDiagnostic(type) {
+        switch(type) {
+            case EntityType.EntityName:
+                return this.getAsEntityDiagnostic();
+            case EntityType.EntitySetName:
+                return this.getAsEntitySetDiagnostic();
+            default:
+                throw `Type '${type}' is not supported`;
+        }
+    }
+
+    getAsEntityDiagnostic() {
+        return new vscode.Diagnostic(this.entityRange, DuplicateEntityNameErrMsg, vscode.DiagnosticSeverity.Error);
+    }
+
+    getAsEntitySetDiagnostic() {
+        return new vscode.Diagnostic(this.entitySetRange, DuplicateEntitySetNameErrMsg, vscode.DiagnosticSeverity.Error);
+    }
+}
+
+class ApiPageEntityAnalyzer {
+    byEntitySetName = new Map();
+    byEntityName = new Map();
+    byPath = new Map();
+    diagnosticEntityNameCollection = vscode.languages.createDiagnosticCollection('AL-Toolbox API Page EntityName Diagnostics');
+    diagnosticEntitySetNameCollection = vscode.languages.createDiagnosticCollection('AL-Toolbox API Page EntitySetName Diagnostics');
+
+    constructor() {
+        this.init();
+    }
+
+    init() {
+        vscode.workspace.findFiles('**/' + alFileManagement.getFileFormatForType(constants.AlObjectTypes.page))
+            .then(fileURIs => {
+                this.analyzeFiles(fileURIs);
+            });
+    }
+
+    /**
+     * @param {string} type
+     */
+    getMapForType(type) {
+        switch(type) {
+            case EntityType.EntityName:
+                return this.byEntityName;
+            case EntityType.EntitySetName:
+                return this.byEntitySetName;
+            default:
+                throw `Unknown EntityType: '${type}'`;
+        }
+    }
+
+    /**
+     * @param {ReadonlyArray<vscode.Uri>} fileURIs 
+     */
+    async analyzeFiles(fileURIs, updateDiagnostics = true) {
+        let didChange = false;
+        await Promise.all(fileURIs.map(async uri => {
+            const textDocument = await vscode.workspace.openTextDocument(uri)
+            let apiPageEntityInfo = new ApiPageEntityInfo(textDocument);
+            if (apiPageEntityInfo.isAPIPage){
+                if(this.byPath.has(uri.fsPath)) {
+                    this.update(apiPageEntityInfo);
+                } else {
+                    this.addToMaps(apiPageEntityInfo);
+                }
+                didChange = true;
+            }
+        }));
+        if(didChange && updateDiagnostics) { this.createDiagnostics(); }
+    }
+
+    //#region Remove
+    /**
+     * @param {ReadonlyArray<vscode.Uri>} fileURIs 
+     */
+    removeFiles(fileURIs, updateDiagnostics = true) {
+        let didRemove = false;
+        fileURIs.forEach(uri => {
+            if(this.byPath.has(uri.fsPath)) {
+                this.removeEntity(this.byPath.get(uri.fsPath));
+                didRemove = true;
+            }
+        });
+        if(didRemove && updateDiagnostics) { this.createDiagnostics(); }
+    }
+
+    /**
+     * @param {ApiPageEntityInfo} apiPageEntityInfo
+     */
+    removeEntity(apiPageEntityInfo) {
+        this.byPath.delete(apiPageEntityInfo.getPath());
+        this.removeFromMap(apiPageEntityInfo, EntityType.EntityName);
+        this.diagnosticEntityNameCollection.delete(apiPageEntityInfo.fileUri);
+        this.removeFromMap(apiPageEntityInfo, EntityType.EntitySetName);
+        this.diagnosticEntitySetNameCollection.delete(apiPageEntityInfo.fileUri);
+    }
+    
+    /**
+     * @param {ApiPageEntityInfo} apiPageEntityInfo 
+     * @param {string} entityType 
+     */
+    removeFromMap(apiPageEntityInfo, entityType) {
+        const entityMap = this.getMapForType(entityType);
+        let entities;
+        const key = apiPageEntityInfo.asKey(entityType);
+        if(entities = entityMap.get(key)) {
+            entities = entities.filter(entity => entity !== apiPageEntityInfo);
+            if(entities.length === 0) {
+                entityMap.delete(key);
+            } else {
+                entityMap.set(key, entities);
+            }
+        }
+    }
+
+    /**
+     * @param {vscode.Uri} uri 
+     */
+    removeFilesInFolder(uri) {
+        this.byPath.forEach((_, key) => {
+            if (key.includes(uri.fsPath)) {
+                this.removeEntity(this.byPath.get(key));
+            }
+        });
+    }
+    //#endregion
+
+    /**
+     * @param {ApiPageEntityInfo} apiPageEntityInfo
+     */
+    update(apiPageEntityInfo) {
+        this.removeEntity(this.byPath.get(apiPageEntityInfo.getPath()));
+        this.addToMaps(apiPageEntityInfo);
+    }
+
+    //#region Add
+    /**
+     * @param {ApiPageEntityInfo} apiPageEntityInfo
+     */
+    addToMaps(apiPageEntityInfo) {
+        this.byPath.set(apiPageEntityInfo.getPath(), apiPageEntityInfo);
+        this.add(apiPageEntityInfo, EntityType.EntityName);
+        this.add(apiPageEntityInfo, EntityType.EntitySetName);
+    }
+
+    /**
+     * @param {ApiPageEntityInfo} apiPageEntityInfo
+     * @param {string} apiPageEntityInfo
+     */
+    add(apiPageEntityInfo, type) {
+        const currMap = this.getMapForType(type)
+        const key = apiPageEntityInfo.asKey(type);
+        if (!currMap.has(key)) {
+            currMap.set(key, [apiPageEntityInfo]);
+        } else {
+            currMap.get(key).push(apiPageEntityInfo);
+        }
+    }
+    //#endregion
+
+    //#region Diagnostics
+    createDiagnostics() {
+        let diagnostics = []
+        this.byEntityName.forEach(entries => {
+            diagnostics = diagnostics.concat(this.createDiagnosticsFor(entries, EntityType.EntityName));
+        });
+        this.diagnosticEntityNameCollection.set(diagnostics);
+        diagnostics = []
+        this.byEntitySetName.forEach(entries => {
+            diagnostics = diagnostics.concat(this.createDiagnosticsFor(entries, EntityType.EntitySetName));
+        });
+        this.diagnosticEntitySetNameCollection.set(diagnostics);
+    }
+
+    /**
+     * @param {Array<ApiPageEntityInfo>} apiPageEntitiesInfo 
+     */
+    createDiagnosticsFor(apiPageEntitiesInfo, type) {
+        const diagnostics = []
+        if (apiPageEntitiesInfo.length > 1) {
+            apiPageEntitiesInfo.forEach(apiPageEntity => {
+                diagnostics.push([apiPageEntity.fileUri, [apiPageEntity.getAsDiagnostic(type)]]);
+            });
+        } else {
+            apiPageEntitiesInfo.forEach(apiPageEntity => {
+                diagnostics.push([apiPageEntity.fileUri, undefined]);
+            });
+        }
+        return diagnostics;
+    }
+    //#endregion
+}
+exports.ApiPageEntityAnalyzer = ApiPageEntityAnalyzer;
+
+/**
+ * 
+ * @param {string|vscode.WorkspaceFolder} workspaceFolder 
+ * @param {ApiPageEntityAnalyzer} apiPageEntityAnalyzer 
+ */
+function createFileSystemWatcher(workspaceFolder, apiPageEntityAnalyzer) {
+    const pageFilePattern =
+        new vscode.RelativePattern(workspaceFolder, '**/' + alFileManagement.getFileFormatForType(constants.AlObjectTypes.page));
+    const fileSystemWatcher = vscode.workspace.createFileSystemWatcher(pageFilePattern);
+    fileSystemWatcher.onDidCreate(uri => {
+        apiPageEntityAnalyzer.analyzeFiles([uri]);
+    });
+    fileSystemWatcher.onDidDelete(uri => {
+        apiPageEntityAnalyzer.removeFiles([uri]);
+    });
+    fileSystemWatcher.onDidChange(uri => {
+        apiPageEntityAnalyzer.analyzeFiles([uri]);
+    });
+    return fileSystemWatcher;
+}
+exports.createFileSystemWatcher = createFileSystemWatcher;

--- a/src/codeAnalyzers/apiPageEntityAnalyzer.js
+++ b/src/codeAnalyzers/apiPageEntityAnalyzer.js
@@ -3,8 +3,8 @@ const fileManagement = require('../fileManagement/fileManagement');
 const alFileManagement = require('../fileManagement/alFileManagement');
 const constants = require('../constants');
 
-const DuplicateEntityNameErrMsg = 'Duplicate entityName';
-const DuplicateEntitySetNameErrMsg = 'Dublicate entitySetName';
+const DuplicateEntityNameErrMsg = 'Duplicate EntityName';
+const DuplicateEntitySetNameErrMsg = 'Duplicate EntitySetName';
 
 const EntityType = {
     EntityName: 'EntityName',

--- a/src/codeBlocks/codeBlocks.js
+++ b/src/codeBlocks/codeBlocks.js
@@ -1,0 +1,122 @@
+const CodeBlockTokenTypes = {
+    STARTOFBLOCK: 0,
+    INCREASE: 1,
+    DECREASE: 2
+}
+/**
+ * @param {string} text 
+ * @param {RegExp} startOfCodeBlockRegex 
+ * @param {RegExp} increaseRegex 
+ * @param {RegExp} decreaseRegex 
+ * 
+ * @returns {Array<{start: number, end: number, indent: number, kind: string}>}
+ */
+exports.findAllCodeBlocks = function findAllCodeBlocks(text, startOfCodeBlockRegex, increaseRegex, decreaseRegex) {
+    if (!startOfCodeBlockRegex.global) console.error('startOfCodeBlockRegex should have option "global"');
+    if (!increaseRegex.global) console.error('increaseRegex should have option "global"');
+    if (!decreaseRegex.global) console.error('decreaseRegex should have option "global"');
+    
+    let locations = [];
+    let match;
+    startOfCodeBlockRegex.lastIndex = 0;
+    while((match = startOfCodeBlockRegex.exec(text)) != null){
+        locations.push({
+            index: match.index,
+            type: CodeBlockTokenTypes.STARTOFBLOCK,
+            blockKind: match.groups['kind']
+        });
+    }
+    increaseRegex.lastIndex = 0;
+    while((match = increaseRegex.exec(text)) != null){
+        locations.push({
+            index: match.index,
+            type: CodeBlockTokenTypes.INCREASE
+        });
+    }
+    decreaseRegex.lastIndex = 0;
+    while((match = decreaseRegex.exec(text)) != null){
+        locations.push({
+            index: match.index,
+            type: CodeBlockTokenTypes.DECREASE
+        });
+    }
+
+    locations = locations.sort((a, b) => a.index - b.index);
+
+    let blocks = [];
+    let blocksStack = [];
+    locations.forEach(location => {
+        switch(location.type){
+            case CodeBlockTokenTypes.STARTOFBLOCK:
+                blocksStack.push({
+                    start: location.index,
+                    end: -1,
+                    indent: 0,
+                    kind: location.blockKind
+                })
+                break;
+            case CodeBlockTokenTypes.INCREASE:
+                if (blocksStack.length > 0)
+                    blocksStack[blocksStack.length-1].indent++;
+                break;
+            case CodeBlockTokenTypes.DECREASE:
+                if (blocksStack.length > 0) {
+                    const currIndent = --blocksStack[blocksStack.length-1].indent;
+                    if (currIndent <= 0) {
+                        let block = blocksStack.pop();
+                        block.end = location.index;
+                        block.indent = blocksStack.length;
+                        blocks.push(block);
+                    }
+                }
+                break;
+        }
+    });
+    
+    return blocks;
+}
+/**
+ * 
+ * @param {Array<{start: number, end: number, indent: number, kind: string}>} codeBlocks 
+ * @param {boolean} checkKind 
+ * 
+ * @returns {Array<{start: number, end: number, indent: number, kind: string, concatCount: number}>}
+ */
+exports.concatCodeBlocksNextToEachOther = function concatCodeBlocksNextToEachOther(codeBlocks, checkKind) {
+    if (codeBlocks.length === 0) return [];
+    codeBlocks = codeBlocks.sort((a, b) => {
+        if (a.indent !== b.indent)
+            return a.indent - b.indent;
+        else
+            a.start - b.start;
+    })
+    let newCodeBlocks = [Object.assign(codeBlocks[0])];
+    newCodeBlocks[0].concatCount = 1;
+    for(let i = 1; i < codeBlocks.length; i++){
+        const nextCodeBlock = Object.assign(codeBlocks[i]);
+        if (nextCodeBlock.start === newCodeBlocks[newCodeBlocks.length-1].end + 1 &&
+                !(checkKind && newCodeBlocks[newCodeBlocks.length-1].kind !== nextCodeBlock.kind)) {
+            newCodeBlocks[newCodeBlocks.length-1].end = nextCodeBlock.end;
+            newCodeBlocks[newCodeBlocks.length-1].concatCount++;
+        } else {
+            nextCodeBlock.concatCount = 1;
+            newCodeBlocks.push(nextCodeBlock);
+        }
+    }
+
+    return newCodeBlocks;
+}
+
+/**
+ * @param {string} text 
+ * @param {{start: number, end: number}} location 
+ */
+exports.getLineNumbersForLocations = function getLineNumbersForLocations(text, location) {
+    let tempString = text.substring(0, location.start);
+    const startLineNo = tempString.split(/\n/).length - 1;
+    tempString = text.substring(location.start, location.end);
+    return {
+        start: startLineNo,
+        end: startLineNo + tempString.split(/\n/).length - 1
+    }
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,7 +9,9 @@ exports.AlObjectTypes = {
     query: 'query',
     profile: 'profile',
     XMLPort: 'xmlport',
-    enum: 'enum'
+    enum: 'enum',
+    controleAddIn: 'controladdin',
+    interface: 'interface',
 }
 
 exports.AlObjectTypesToFilePrefix = (AlObjectType) => {
@@ -31,6 +33,10 @@ exports.AlObjectTypesToFilePrefix = (AlObjectType) => {
 		    return 'Prof';
         case this.AlObjectTypes.XMLPort:
             return 'Xml';
+        case this.AlObjectTypes.controleAddIn:
+            return 'ControlAddin';
+        case this.AlObjectTypes.interface:
+            return 'Iface';
         default:
             return '';
     }
@@ -58,9 +64,22 @@ exports.AlObjectTypesToFullTypeName = (AlObjectType) => {
 		    return 'Profile';
         case this.AlObjectTypes.XMLPort:
             return 'Xmlport';
+        case this.AlObjectTypes.controleAddIn:
+            return 'ControlAddin';
+        case this.AlObjectTypes.interface:
+            return 'Interface';
         default:
             return '';
     }
+}
+
+exports.ExtensionObjectNumber = 80000;
+
+/**
+ * @param {string} objectType 
+ */
+exports.isExtensionType = (objectType) => {
+    return objectType.match(/extension/i) !== null;
 }
 
 exports.RelatedTables = [

--- a/src/constants.js
+++ b/src/constants.js
@@ -82,9 +82,9 @@ exports.isExtensionType = (objectType) => {
     return objectType.match(/extension/i) !== null;
 }
 
-exports.RelatedTables = [
+exports.RelatedObjects = [
+    //#region Tables
     {
-        table: 'Contact',
         folder: 'Contact',
         objectType: this.AlObjectTypes.tableExtension,
         objects: [
@@ -95,7 +95,6 @@ exports.RelatedTables = [
         ]
     },
     {
-        table: 'Sales Header',
         folder: 'SalesHeader',
         objectType: this.AlObjectTypes.tableExtension,
         objects: [
@@ -108,7 +107,6 @@ exports.RelatedTables = [
         ]
     },
     {
-        table: 'Sales Line',
 		folder: 'SalesLine',
         objectType: this.AlObjectTypes.tableExtension,
         objects: [
@@ -121,7 +119,6 @@ exports.RelatedTables = [
         ]
     },
     {
-        table: 'Purchase Header',
 		folder: 'PurchaseHeader',
         objectType: this.AlObjectTypes.tableExtension,
         objects: [
@@ -134,7 +131,6 @@ exports.RelatedTables = [
         ]
     },
     {
-        table: 'Purchase Line',
 		folder: 'PurchaseLine',
         objectType: this.AlObjectTypes.tableExtension,
         objects: [
@@ -146,6 +142,7 @@ exports.RelatedTables = [
             { id: 6651, name: 'Return Shipment Line' }
         ]
     },
+    //#endregion
     //#region Pages form tables related to Contact
     {
         table: 'Contact',

--- a/src/fault.js
+++ b/src/fault.js
@@ -1,0 +1,28 @@
+const vscode = require('vscode');
+
+class Fault {
+    message;
+    uri;
+    range;
+
+    /**
+     * @param {string} message
+     * @param {vscode.Uri} uri
+     * @param {vscode.Range} range
+     */
+    constructor(message, uri, range) {
+        this.message = message;
+        this.uri = uri;
+        this.range = range;
+    }
+
+    async goto() {
+        const textDoc = await vscode.workspace.openTextDocument(this.uri);
+        const textEditor = await vscode.window.showTextDocument(textDoc);
+        if(this.range) {
+            textEditor.revealRange(this.range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+            textEditor.selection = new vscode.Selection(this.range.start, this.range.end)
+        }
+    }
+}
+exports.Fault = Fault;

--- a/src/fileManagement/alFileManagement.js
+++ b/src/fileManagement/alFileManagement.js
@@ -153,3 +153,51 @@ exports.getFileFormatForType = function getFileFormatForType(alObjectType) {
 
     return fileLocationFormat;
 };
+
+const alObjectRegex = /(?<type>\w+)(\s+(?<id>\d+))?\s+(?<name>\w+|"[^"]*")(\s+extends\s+(?<extendedName>\w+|"[^"]*")(\s*\/\/\s*(?<extendedId>\d+))?|\s+implements\s+(?<interfaces>(\w+|"[^"]*")(\s*,\s*(\w+|"[^"]*"))*))?/i;
+class AlObjectInfo {
+    type;
+    id;
+    name;
+    extendedName;
+    extendedId;
+    interfaces;
+
+    path;
+
+    /**
+     * @param {vscode.TextDocument} textDocument  
+     */
+    constructor(textDocument) {
+        this.path = textDocument.uri;
+        const match = alObjectRegex.exec(textDocument.getText());
+        this.type = match.groups.type.toLowerCase();
+        if(Object.values(constants.AlObjectTypes).includes(this.type)){
+            this.name = match.groups.name;
+            
+            if(this.type !== constants.AlObjectTypes.interface && this.type !== constants.AlObjectTypes.controleAddIn)
+                this.id = Number(match.groups.id);
+
+            if(constants.isExtensionType(this.type)) {
+                this.extendedName = match.groups.extendedName;
+                this.extendedId = match.groups.extendedId;
+                if(this.extendedId) {
+                    this.extendedId = Number(this.extendedId);
+                }
+            }
+
+            if(this.type === constants.AlObjectTypes.codeUnit && match.groups.interfaces) {
+                this.interfaces = match.groups.interfaces.split(",").map(interfaceName => {
+                    return interfaceName.trim();
+                });
+            }
+        } else {
+            this.type = undefined;
+        }
+    }
+
+    isExtensionObject() {
+        return this.extendedName !== undefined;
+    }
+}
+exports.AlObjectInfo = AlObjectInfo;

--- a/src/fileManagement/alFileManagement.js
+++ b/src/fileManagement/alFileManagement.js
@@ -129,7 +129,7 @@ function getAlFileLocations(objectName, alObjectType){
         fileLocationFormat += `${filePrefix}*${compactObjectName}.al`;
     } else {
         const fullTypeName = constants.AlObjectTypesToFullTypeName(alObjectType);
-        fileLocationFormat += `${compactObjectName}.${fullTypeName}.al`;
+        fileLocationFormat += `*${compactObjectName}.${fullTypeName}.al`;
     }
 
     return glob.sync(fileLocationFormat);
@@ -173,13 +173,13 @@ class AlObjectInfo {
         const match = alObjectRegex.exec(textDocument.getText());
         this.type = match.groups.type.toLowerCase();
         if(Object.values(constants.AlObjectTypes).includes(this.type)){
-            this.name = match.groups.name;
+            this.name = match.groups.name.replace(/"/g, '');
             
             if(this.type !== constants.AlObjectTypes.interface && this.type !== constants.AlObjectTypes.controleAddIn)
                 this.id = Number(match.groups.id);
 
             if(constants.isExtensionType(this.type)) {
-                this.extendedName = match.groups.extendedName;
+                this.extendedName = match.groups.extendedName.replace(/"/g, '');
                 this.extendedId = match.groups.extendedId;
                 if(this.extendedId) {
                     this.extendedId = Number(this.extendedId);

--- a/src/fileManagement/fileManagement.js
+++ b/src/fileManagement/fileManagement.js
@@ -114,3 +114,26 @@ async function applyEditAndSave(textDocument, textEdits) {
         });
 }
 exports.applyEditAndSave = applyEditAndSave;
+
+/**
+ * Gets the position of the matched text as vscode.Range
+ * @param {RegExpExecArray} match
+ */
+exports.getMatchRange = function getMatchRange(match) {
+    const textLinesBeforeMatch = match.input.substring(0, match.index).split(/\n/g);
+    let lineNo = textLinesBeforeMatch.length - 1;
+    let charNo = textLinesBeforeMatch[textLinesBeforeMatch.length - 1].length;
+    const matchStartPos = new vscode.Position(lineNo, charNo);
+
+    const textLinesInMatch = match.input.substring(match.index, match.index + match[0].length).split(/\n/g);
+    lineNo += textLinesInMatch.length - 1;
+    if(textLinesInMatch.length === 1) {
+        // is on same line as matchStartPos
+        charNo += textLinesInMatch[0].length;
+    } else {
+        charNo = textLinesInMatch[textLinesInMatch.length - 1].length;
+    }
+    const matchEndPos = new vscode.Position(lineNo, charNo);
+    
+    return new vscode.Range(matchStartPos, matchEndPos);
+}

--- a/src/regionWrapper/regionWrapper.js
+++ b/src/regionWrapper/regionWrapper.js
@@ -1,4 +1,5 @@
 const vscode = require('vscode');
+const codeBlocks = require('../codeBlocks/codeBlocks');
 // import * as vscode from 'vscode';
 
 const regionStartRegex = /\/\/#region\b/;
@@ -19,11 +20,11 @@ exports.WrapAllFunctions = (editBuilder, document) => {
     text = replaceBlockCommentsWithNewlines(text);
     text = text.replace(stringRegex, '""'); // replaced with "" so alFunctionRegex still recognizes function like: 'procedure "function b"(...)'
     
-    let alFunctionLocations = findAllCodeBlocks(text, alFunctionRegex, beginRegex, endRegex);
+    let alFunctionLocations = codeBlocks.findAllCodeBlocks(text, alFunctionRegex, beginRegex, endRegex);
     
     let regionCount = 0;
     alFunctionLocations.forEach(location => {
-        const lineNos = getLineNumbersForLocations(text, location);
+        const lineNos = codeBlocks.getLineNumbersForLocations(text, location);
         if ((lineNos.start === 0) ||
                 !regionStartRegex.test(document.lineAt(lineNos.start-1).text)) { // check if line before function does not contain a region
             const regionName = getRegionNameForAlFunction(document, lineNos.start);
@@ -48,13 +49,13 @@ exports.WrapAllDataItemsAndColumns = (editBuilder, document, skipSingelInstance)
     text = text.replace(commandRegex, '');
     text = text.replace(stringRegex, '');
 
-    let dataitemAndColumnLocations = findAllCodeBlocks(text, DataItemOrColumnRegex, /\{/g, /\}/g);
+    let dataitemAndColumnLocations = codeBlocks.findAllCodeBlocks(text, DataItemOrColumnRegex, /\{/g, /\}/g);
     dataitemAndColumnLocations.forEach(location => {
-        const lineNos = getLineNumbersForLocations(text, location);
+        const lineNos = codeBlocks.getLineNumbersForLocations(text, location);
         location.start = lineNos.start;
         location.end = lineNos.end;
     });
-    let concatinatedBloks = concatCodeBlocksNextToEachOther(dataitemAndColumnLocations, true);
+    let concatinatedBloks = codeBlocks.concatCodeBlocksNextToEachOther(dataitemAndColumnLocations, true);
 
     let regionCount = 0;
     concatinatedBloks.forEach(location => {
@@ -71,98 +72,6 @@ exports.WrapAllDataItemsAndColumns = (editBuilder, document, skipSingelInstance)
     });
 
     return regionCount;
-}
-
-const CodeBlockTokenTypes = {
-    STARTOFBLOCK: 0,
-    INCREASE: 1,
-    DECREASE: 2
-}
-/**
- * @param {string} text 
- * @param {RegExp} startOfCodeBlockRegex 
- * @param {RegExp} increaseRegex 
- * @param {RegExp} decreaseRegex 
- * 
- * @returns {Array<{start: number, end: number, indent: number, kind: string}>}
- */
-function findAllCodeBlocks(text, startOfCodeBlockRegex, increaseRegex, decreaseRegex) {
-    if (!startOfCodeBlockRegex.global) console.error('startOfCodeBlockRegex should have option "global"');
-    if (!increaseRegex.global) console.error('increaseRegex should have option "global"');
-    if (!decreaseRegex.global) console.error('decreaseRegex should have option "global"');
-    
-    let locations = [];
-    let match;
-    startOfCodeBlockRegex.lastIndex = 0;
-    while((match = startOfCodeBlockRegex.exec(text)) != null){
-        locations.push({
-            index: match.index,
-            type: CodeBlockTokenTypes.STARTOFBLOCK,
-            blockKind: match.groups['kind']
-        });
-    }
-    increaseRegex.lastIndex = 0;
-    while((match = increaseRegex.exec(text)) != null){
-        locations.push({
-            index: match.index,
-            type: CodeBlockTokenTypes.INCREASE
-        });
-    }
-    decreaseRegex.lastIndex = 0;
-    while((match = decreaseRegex.exec(text)) != null){
-        locations.push({
-            index: match.index,
-            type: CodeBlockTokenTypes.DECREASE
-        });
-    }
-
-    locations = locations.sort((a, b) => a.index - b.index);
-
-    let blocks = [];
-    let blocksStack = [];
-    locations.forEach(location => {
-        switch(location.type){
-            case CodeBlockTokenTypes.STARTOFBLOCK:
-                blocksStack.push({
-                    start: location.index,
-                    end: -1,
-                    indent: 0,
-                    kind: location.blockKind
-                })
-                break;
-            case CodeBlockTokenTypes.INCREASE:
-                if (blocksStack.length > 0)
-                    blocksStack[blocksStack.length-1].indent++;
-                break;
-            case CodeBlockTokenTypes.DECREASE:
-                if (blocksStack.length > 0) {
-                    const currIndent = --blocksStack[blocksStack.length-1].indent;
-                    if (currIndent <= 0) {
-                        let block = blocksStack.pop();
-                        block.end = location.index;
-                        block.indent = blocksStack.length;
-                        blocks.push(block);
-                    }
-                }
-                break;
-        }
-    });
-    
-    return blocks;
-}
-
-/**
- * @param {string} text 
- * @param {{start: number, end: number}} location 
- */
-function getLineNumbersForLocations(text, location) {
-    let tempString = text.substring(0, location.start);
-    const startLineNo = tempString.split(/\n/).length - 1;
-    tempString = text.substring(location.start, location.end);
-    return {
-        start: startLineNo,
-        end: startLineNo + tempString.split(/\n/).length - 1
-    }
 }
 
 /**
@@ -212,38 +121,6 @@ function getRegionNameForAlFunction(document, lineNo) {
         return '"error function name not found"';
     }
     return match.groups['name'];
-}
-
-/**
- * 
- * @param {Array<{start: number, end: number, indent: number, kind: string}>} codeBlocks 
- * @param {boolean} checkKind 
- * 
- * @returns {Array<{start: number, end: number, indent: number, kind: string, concatCount: number}>}
- */
-function concatCodeBlocksNextToEachOther(codeBlocks, checkKind) {
-    if (codeBlocks.length === 0) return [];
-    codeBlocks = codeBlocks.sort((a, b) => {
-        if (a.indent !== b.indent)
-            return a.indent - b.indent;
-        else
-            a.start - b.start;
-    })
-    let newCodeBlocks = [Object.assign(codeBlocks[0])];
-    newCodeBlocks[0].concatCount = 1;
-    for(let i = 1; i < codeBlocks.length; i++){
-        const nextCodeBlock = Object.assign(codeBlocks[i]);
-        if (nextCodeBlock.start === newCodeBlocks[newCodeBlocks.length-1].end + 1 &&
-                !(checkKind && newCodeBlocks[newCodeBlocks.length-1].kind !== nextCodeBlock.kind)) {
-            newCodeBlocks[newCodeBlocks.length-1].end = nextCodeBlock.end;
-            newCodeBlocks[newCodeBlocks.length-1].concatCount++;
-        } else {
-            nextCodeBlock.concatCount = 1;
-            newCodeBlocks.push(nextCodeBlock);
-        }
-    }
-
-    return newCodeBlocks;
 }
 
 function replaceBlockCommentsWithNewlines(text) {

--- a/src/relatedTables/copyFieldsToRelatedTables.js
+++ b/src/relatedTables/copyFieldsToRelatedTables.js
@@ -1,0 +1,122 @@
+const vscode = require('vscode');
+const codeBlocks = require('../codeBlocks/codeBlocks');
+const alFileManagement = require('../fileManagement/alFileManagement');
+const fault = require('../fault');
+
+const openBracked = /\{/g;
+const closeBracked = /\}/g;
+
+/**
+ * @param {vscode.TextDocument} sourceDocument
+ * @param {Array<vscode.TextDocument>} destinationDocuments
+ */
+exports.copyFieldsToRelatedTables = async (sourceDocument, destinationDocuments) => {
+    const currentTableFields = getFields(sourceDocument);
+    const faults = [];
+    let nrFilesChanged = 0;
+    let nrFieldsAdded = 0; 
+
+    await Promise.all(destinationDocuments.map(async document => {
+        const destTableFields = new Map();
+        getFields(document).forEach(fieldInfo => destTableFields.set(fieldInfo.number, fieldInfo));
+        
+        const fieldsToAdd = [];
+        // Get all fields in currentTableFields that are not in document
+        currentTableFields.forEach(fieldInfo => {
+            if (destTableFields.has(fieldInfo.number)) {
+                const destFieldinfo = destTableFields.get(fieldInfo.number);
+                if (destFieldinfo.name !== fieldInfo.name || destFieldinfo.type !== fieldInfo.type) {
+                    const differentKind = destFieldinfo.name !== fieldInfo.name ? 'name' : 'type';
+
+                    const objectInfo = new alFileManagement.AlObjectInfo(document);
+                    const destFieldRegex = new RegExp(fieldRegex.source.replace('(?<no>\\d+)', destFieldinfo.number.toString()));
+                    const match = destFieldRegex.exec(document.getText());
+                    
+                    faults.push(new fault.Fault(
+                        `FieldNo ${fieldInfo.number} already exists in tableExtension ${objectInfo.name} with a different ${differentKind}: ${destFieldinfo[differentKind]} (instead of ${fieldInfo[differentKind]})`,
+                        document.uri,
+                        new vscode.Range(document.positionAt(match.index), document.positionAt(match.index + match[0].length))
+                    ));
+                }
+            } else {
+                fieldsToAdd.push(fieldInfo);
+            }
+        });
+
+        if (fieldsToAdd.length > 0) {
+            let fieldsText = "";
+            fieldsToAdd.forEach(fieldInfo => {
+                fieldsText += fieldInfo.body;
+            });
+            
+            const text = codeBlocks.removeAllCommentsAndStrings(document.getText());
+            const fieldsCodeBlocks = codeBlocks.findAllCodeBlocks(
+                text,
+                /\b(?<kind>fields)\s*(?=\{)/ig,
+                openBracked,
+                closeBracked
+            )
+            const lineNos = codeBlocks.getLineNumbersForLocations(text, fieldsCodeBlocks[0]);
+
+            const edit = new vscode.WorkspaceEdit();
+            edit.insert(document.uri, new vscode.Position(lineNos.end, 0), fieldsText);
+            const appliedEdit = await vscode.workspace.applyEdit(edit);
+
+            if (appliedEdit) {
+                ++nrFilesChanged;
+                nrFieldsAdded += fieldsToAdd.length;
+                document.save();
+            } else {
+                faults.push(
+                    new fault.Fault(`Failed to edit ${document.uri}`, document.uri, undefined));
+            }
+        }
+    }));
+
+    return {
+        nrFilesChanged: nrFilesChanged,
+        nrFieldsAdded: nrFieldsAdded,
+        faults: faults
+    }
+}
+
+const fieldRegex = /\b(?<kind>field)\s*\(\s*(?<no>\d+)\s*;\s*(?<name>"[^"]*"|\w+)\s*;\s*(?<type>[^\)]+)\s*\)/gm;
+class FieldInfo {
+    number;
+    name;
+    type;
+    body;
+
+    /**
+     * @param {string} body
+     */
+    constructor(body){
+        const match = fieldRegex.exec(body);
+        this.number = Number(match.groups.no);
+        this.name = match.groups.name.replace(/"/g, '');
+        this.type = match.groups.type;
+        this.body = body;
+    }
+}
+
+/**
+ * @param {vscode.TextDocument} document
+ * @returns {FieldInfo[]}
+ */
+function getFields(document) {
+    let text = document.getText();
+    text = codeBlocks.removeAllCommentsAndStrings(text);
+    let fields = codeBlocks.findAllCodeBlocks(text, fieldRegex, openBracked, closeBracked)
+        .map(codeblock => {
+            const lineNos = codeBlocks.getLineNumbersForLocations(text, codeblock);
+            const range = new vscode.Range(
+                new vscode.Position(lineNos.start, 0),
+                new vscode.Position(lineNos.end+1, 0)
+            );
+            const body = document.getText(range);
+            fieldRegex.lastIndex = 0;
+            
+            return new FieldInfo(body);
+        });
+    return fields;
+}

--- a/src/relatedTables/relatedTables.js
+++ b/src/relatedTables/relatedTables.js
@@ -21,7 +21,7 @@ exports.createRelatedTables = function createRelatedTables(objectNamePrefix, fil
 
     let destinationPath;
     const fileCreationPromises = [];
-    constants.RelatedTables.forEach(element => {
+    getRelatedObjectData().forEach(element => {
         destinationPath = baseDestinationPath + element.objectType;
         fileMangagement.createFolder(destinationPath);
         destinationPath += '/' + element.folder
@@ -41,13 +41,13 @@ exports.RelatedTablesManager = class RelatedTablesManager {
     pageToRelatedTable;
 
     constructor() {
-        this.setTableAndPageToRelatedObjects();
+        this.setTableAndPageToRelatedObjects(getRelatedObjectData());
     }
 
-    setTableAndPageToRelatedObjects() {
+    setTableAndPageToRelatedObjects(relatedObjects) {
         this.tableToRelatedObjects = new Map();
         this.pageToRelatedTable = new Map();
-        constants.RelatedTables.forEach(element => {
+        relatedObjects.forEach(element => {
             if (element.objectType === constants.AlObjectTypes.tableExtension) {
                 element.objects.forEach(object1 => {
                     if (!this.tableToRelatedObjects.has(object1.name)) {
@@ -165,3 +165,8 @@ exports.getExtensionObjectInfo = function getExtensionObjectInfo(document){
     return match.groups;
 }
 //#endregion
+
+function getRelatedObjectData() {
+    const additionalObjects = vscode.workspace.getConfiguration('ALTB').get('AdditionalRelatedObjects');
+    return constants.RelatedObjects.concat(additionalObjects);
+}


### PR DESCRIPTION
Added 'Duplicate EntityName' & 'Duplicate EntitySetName' error.
These will occur if multiple Page Object with PageType = 'API' the following fields in common:
  - APIPublisher
  - APIGroup
  - APIVersion

And either (or both) of the following fields:
  - EntityName
  - EntitySetName

To disable this you can use the ALTB.DisbleAPIEntityWarnings setting in the workspace settings (this is not available in folder settings).

Command "ALTB: Renumber AL objects" now renumbers Extension objects:
  - If 80.000 is not in the number ranges the same renumber method is used as for non-extension objects
  - This is also the case number of the extended object isn't found:
      - Format for finding extended object number is `<extension object type> <number> extends <extended object> //<extended object id>`
      - e.g. `pageextension 80000 "EXTItemList" extends "Item List" //31` -> 31 is extended object number
  - If 80.000 is in the number ranges the following formula is used: `80000 + (<extended object id> % 10000)`

Added command "ALTB: Copy fields to related tables" which copies all fields to all related tables (skips fields that are already on the related tables).

Added setting "ALTB.AdditionalRelatedObjects". With this setting you can add additional related objects using the following format:
```
[
    {  // For adding tableextensions
        folder: 'SalesHeader', // subfolder of src where to place the objects when using "ALTB: Start Project: Create Related Tables"
        objectType: this.AlObjectTypes.tableExtension,
        objects: [ // these tables wil be considered related
            { id: 36, name: 'Sales Header' },
            { id: 110, name: 'Sales Shipment Header' },
            { id: 112, name: 'Sales Invoice Header' },
            { id: 114, name: 'Sales Cr.Memo Header' },
            { id: 5107, name: 'Sales Header Archive' },
            { id: 6660, name: 'Return Receipt Header' }
        ]
    },
    ...
    {  // For adding pageextensions
        table: 'Contact',  // source table of pageextension
        folder: 'Contact',   // subfolder of src where to place the objects when using "ALTB: Start Project: Create Related Tables"
        objectType: this.AlObjectTypes.pageExtension,
        objects: [  // pages for the source table
            { id: 5050, name: 'Contact Card' },
            { id: 5052, name: 'Contact List' }
        ]
    },
    ...
]
```
