### PR TITLE
Change object prefix & renumber objects more robust

### DIFF
--- a/src/changePrefix/changePrefix.js
+++ b/src/changePrefix/changePrefix.js
@@ -14,9 +14,9 @@ exports.changeObjectPrefix = async function changeObjectPrefix(currPrefix, newPr
     
     const nameRegex = `("${currPrefix}[^"]+"|${currPrefix}\\w+)`;
     const objectPrefixRegex = new RegExp(
-        `(?<=^\s*${objectTypeRegex}(\\s+\\d+)?\\s+)${nameRegex}`, 'g');
+        `(?<=^\\s*${objectTypeRegex}(\\s+\\d+)?\\s+)${nameRegex}`, 'gi');
     const fieldPrefixRegex = new RegExp(
-        `(?<=field\\((\\d+;\\s*)?)${nameRegex}`, 'g');
+        `(?<=field\\((\\d+;\\s*)?)${nameRegex}`, 'gi');
     const currPrefixRegex = new RegExp(currPrefix);
     
     const currWorkspace = workspaceManagement.getCurrentWorkspaceFolderPath()

--- a/src/extension.js
+++ b/src/extension.js
@@ -112,14 +112,12 @@ function activate(context) {
     //#endregion
 
     context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.renumberAll', () => {
-        renumber.renumberAll().then(result => {
+        renumber.renumberAll().then(results => {
                 let numberOfDocumentsChanged = 0;
-                result.forEach(list => 
-                    list.forEach(changed => {
+                results.forEach(changed => {
                         if (changed) ++numberOfDocumentsChanged;
-                    })
-                );
-                SaveAndCloseAll();
+                });
+                if (numberOfDocumentsChanged > 0) SaveAndCloseAll();
                 vscode.window.showInformationMessage(`${numberOfDocumentsChanged} objects(s) renumbered.`);
             }, error => 
                 vscode.window.showErrorMessage('An error occured: ' + error)

--- a/src/fileManagement/alFileManagement.js
+++ b/src/fileManagement/alFileManagement.js
@@ -154,7 +154,7 @@ exports.getFileFormatForType = function getFileFormatForType(alObjectType) {
     return fileLocationFormat;
 };
 
-const alObjectRegex = /(?<type>\w+)(\s+(?<id>\d+))?\s+(?<name>\w+|"[^"]*")(\s+extends\s+(?<extendedName>\w+|"[^"]*")(\s*\/\/\s*(?<extendedId>\d+))?|\s+implements\s+(?<interfaces>(\w+|"[^"]*")(\s*,\s*(\w+|"[^"]*"))*))?/i;
+const alObjectRegex = /^\s*(?<type>\w+)(\s+(?<id>\d+))?\s+(?<name>\w+|"[^"]*")(\s+extends\s+(?<extendedName>\w+|"[^"]*")(\s*\/\/\s*(?<extendedId>\d+))?|\s+implements\s+(?<interfaces>(\w+|"[^"]*")(\s*,\s*(\w+|"[^"]*"))*))?/im;
 class AlObjectInfo {
     type;
     id;
@@ -171,6 +171,7 @@ class AlObjectInfo {
     constructor(textDocument) {
         this.path = textDocument.uri;
         const match = alObjectRegex.exec(textDocument.getText());
+        if (match === null) return;
         this.type = match.groups.type.toLowerCase();
         if(Object.values(constants.AlObjectTypes).includes(this.type)){
             this.name = match.groups.name.replace(/"/g, '');


### PR DESCRIPTION
Fixed problem with recognizing al-objects if they had comments on the first line, white spaces before the object definition & is now case insensitive.