### PR TITLE
Support for regions without '//' (runtime 6.0+)

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,18 @@
                         "default": true,
                         "description": "If false all objects created with 'ALTB: Start Project: Create Related Tables' is put in there respective object folder. If true each group of related objects are put in a subfolder of that object folder.",
                         "scope": "resource"
+                    },
+                    "ALTB.UseAlRegions": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Use the standard AL regions instead of the regions previously used by this extension (No longer with '//'). This will only have effect if the runtime in app.json is higher than or equal to 6.0",
+                        "scope": "window"
+                    },
+                    "ALTB.DisableCustomFolding": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Disable all folding provided by this extension (requires reload)",
+                        "scope": "window"
                     }
                 }
             }

--- a/src/codeFixers/AL0666.js
+++ b/src/codeFixers/AL0666.js
@@ -1,0 +1,23 @@
+const vscode = require('vscode');
+const codeFixer = require('./codeFixer');
+
+
+class RegionFixer extends codeFixer.CodeFixer {
+    /**
+     * @param {vscode.ExtensionContext} context 
+     * @param {string} dignosticCode 
+     */
+    constructor(context, dignosticCode){
+        super(context, dignosticCode, addSlashes, "ALTB: Add '//'", 'al-toolbox.addSlashes');
+    }
+}
+exports.RegionFixer = RegionFixer;
+
+/**
+ * @param {vscode.WorkspaceEdit} edit
+ * @param {vscode.Uri} uri
+ * @param {vscode.Diagnostic} diagnostic 
+ */
+async function addSlashes(edit, uri, diagnostic) {
+    edit.insert(uri, diagnostic.range.start, '//');
+}

--- a/src/codeFixers/AlCodeActionProvider.js
+++ b/src/codeFixers/AlCodeActionProvider.js
@@ -2,6 +2,7 @@ const vscode = require('vscode');
 const codeFixer = require('./codeFixer');
 const AA0008 = require('./AA0008');
 const AA0139 = require('./AA0139');
+const AL0666 = require('./AL0666');
 
 exports.AlCodeActionProvider = class AlCodeActionProvider {
     relevantDiagnostics;
@@ -15,6 +16,7 @@ exports.AlCodeActionProvider = class AlCodeActionProvider {
         this.diagnosticCodeToFix = {
             'AA0008': new AA0008.MissingBracketsCodeFixer(context, 'AA0008'),
             'AA0139': new AA0139.PossibleOverflowCodeFixer(context, 'AA0139'),
+            'AL0666': new AL0666.RegionFixer(context, 'AL0666')
         }
         this.relevantDiagnostics = Object.keys(this.diagnosticCodeToFix);
     }

--- a/src/extension.js
+++ b/src/extension.js
@@ -91,26 +91,29 @@ function activate(context) {
     //#endregion
     
     //#region Wrapping
-    context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.wrapAllFunctions', function () {
+    context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.wrapAllFunctions', async function () {
         let editor = vscode.window.activeTextEditor;
         let numberOfRegions; 
+        const regionFormat = await regionWrapper.getRegionFormat();
         editor.edit(editBuilder => {
-            numberOfRegions = regionWrapper.WrapAllFunctions(editBuilder, editor.document);
+            numberOfRegions = regionWrapper.WrapAllFunctions(editBuilder, editor.document, regionFormat);
         }).then(() => vscode.window.showInformationMessage(numberOfRegions +' region(s) created.'));
     }));
-    context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.wrapAllDataItemsAndColumns', function () {
+    context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.wrapAllDataItemsAndColumns', async function () {
         let editor = vscode.window.activeTextEditor;
         let numberOfRegions; 
+        const regionFormat = await regionWrapper.getRegionFormat();
         editor.edit(editBuilder => {
-            numberOfRegions = regionWrapper.WrapAllDataItemsAndColumns(editBuilder, editor.document, false);
+            numberOfRegions = regionWrapper.WrapAllDataItemsAndColumns(editBuilder, editor.document, false, regionFormat);
         }).then(() => vscode.window.showInformationMessage(numberOfRegions +' region(s) created.'));
     }));
-    context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.wrapAll', function () {
+    context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.wrapAll', async function () {
         let editor = vscode.window.activeTextEditor;
         let numberOfRegions;
+        const regionFormat = await regionWrapper.getRegionFormat();
         editor.edit(editBuilder => {
-            numberOfRegions = regionWrapper.WrapAllFunctions(editBuilder, editor.document);
-            numberOfRegions += regionWrapper.WrapAllDataItemsAndColumns(editBuilder, editor.document, false);
+            numberOfRegions = regionWrapper.WrapAllFunctions(editBuilder, editor.document, regionFormat);
+            numberOfRegions += regionWrapper.WrapAllDataItemsAndColumns(editBuilder, editor.document, false, regionFormat);
         }).then(() => vscode.window.showInformationMessage(numberOfRegions +' region(s) created.'));
     }));
     //#endregion
@@ -203,8 +206,11 @@ function activate(context) {
             { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix] }
     ));
 
-    context.subscriptions.push(vscode.languages.registerFoldingRangeProvider('al', new regionFolding.RegionFoldingRangeProvider()));
-    context.subscriptions.push(vscode.languages.registerFoldingRangeProvider('al', new indentFolding.IndentFoldingRangeProvider()));
+    const disableCustomFolding = vscode.workspace.getConfiguration('ALTB').get('DisableCustomFolding');
+    if (!disableCustomFolding) {
+        context.subscriptions.push(vscode.languages.registerFoldingRangeProvider('al', new regionFolding.RegionFoldingRangeProvider()));
+        context.subscriptions.push(vscode.languages.registerFoldingRangeProvider('al', new indentFolding.IndentFoldingRangeProvider()));
+    }
 }
 
 // this method is called when your extension is deactivated

--- a/src/language/regionFolding.js
+++ b/src/language/regionFolding.js
@@ -11,7 +11,11 @@ class RegionFoldingRangeProvider {
     provideFoldingRanges(document, _, token) {
         return getRegions(document.getText(), /^\s*\/\/\s*#region\b/, /^\s*\/\/\s*#endregion\b/, token).map(value => {
             return new vscode.FoldingRange(value.start, value.end, vscode.FoldingRangeKind.Region);
-        });
+        }).concat(
+            getRegions(document.getText(), /^\s*#region\b/, /^\s*#endregion\b/, token).map(value => {
+                return new vscode.FoldingRange(value.start, value.end, vscode.FoldingRangeKind.Region);
+            })
+        );
     }
 
 }


### PR DESCRIPTION
Added
- Folding for regions without '//'
- Option to disable all folding provided by this extension: ALTB.DisableCustomFolding
- Option to use region without '//' for region generation (snippets still use '//'): ALTB.UseAlRegions
- Added quick fix for AL0666 -> transforms region without '//' to regions with them.