### PR TITLE
Generate SetLoadFields & Show field description on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,3 +89,4 @@ Added Command:
 
 ## [2.0.5]
 - Added command "ALTB: Generate SetLoadFields"
+- Show field description on hover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,3 +86,6 @@ Added Command:
 
 ## [2.0.2]
 - Added option to disable snippets: ALTB.DisableSnippets
+
+## [2.0.5]
+- Added command "ALTB: Generate SetLoadFields"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ This extension has been inspired by the GitHub user RafaelKoch with his post htt
 - ALTB.RegionTextColor | Color: default `#D4D4D4` ~ white
     - Color of text after region markers. Set to `""` to disable coloring.
 
+- ALTB.DisableHoverProviders | Boolean: default `false`
+    - AL Toolbox shows the field description on hover.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -36,17 +36,22 @@ This extension has been inspired by the GitHub user RafaelKoch with his post htt
 
     ![Popup](resources/CopyFieldConflictPopup.png)
 - ALTB: init .gitignore | Creates the following .gitignore in the current workspace folder or appends the missing lines to the existing .gitignore
-```
-# ALTB
-.alpackages/
-.alcache/
-*.json
-!app.json
-rad.json
-*.app
-```
+    ```
+    # ALTB
+    .alpackages/
+    .alcache/
+    *.json
+    !app.json
+    rad.json
+    *.app
+    ```
 
 - ALTB: Add region | Creates region around the selected text.
+- ALTB: Generate SetLoadFields | Creates SetLoadFields or adds missing fields to SetLoadFields for a record.
+    - Looks for a record at the current mouse position.
+    - Only works for local records.
+    - For each Get, Find, FindFirst, ... a SetLoadFields function is generated the line before it, unless it already exists.
+    - All used fields are added. Assignment is not seen as usage.
 
 ## Settings
 
@@ -89,8 +94,24 @@ rad.json
 
 - ALTB: Change Object Prefix
     - This will only change the prefix of object names and fields.
-    So not for actions, events subscribers, parts on pages, keys... 
+    So not for actions, events subscribers, parts on pages, keys...
 
+- ALTB: Generate SetLoadFields
+    - If there's a Get, Find, ... in a statement over multiple lines, the genered code can be incorrect. e.g:
+        ```
+        if
+            RecVar.Get()
+        then
+            TestFunction(RecVar.TestField);
+
+        // Will genereate:
+        if
+            RecVar.SetLoadFields(TestField);
+            RecVar.Get()
+        then
+            TestFunction(RecVar.TestField);
+        ```
+    
 ## Before After
 ![BeforeAfter](resources/BeforeAfter.png)
 
@@ -104,7 +125,7 @@ Example format:
     {  // For adding tableextensions
         folder: 'SalesHeader', // subfolder of src where to place the objects when using "ALTB: Start Project: Create Related Tables"
         objectType: this.AlObjectTypes.tableExtension,
-        objects: [ // these tables wil be considered related
+        objects: [ // these tables will be considered related
             { id: 36, name: 'Sales Header' },
             { id: 110, name: 'Sales Shipment Header' },
             { id: 112, name: 'Sales Invoice Header' },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "al-toolbox",
     "displayName": "AL Toolbox",
     "description": "AL Language Regions and Snippets",
-    "version": "2.0.2",
+    "version": "2.0.5",
     "publisher": "BartPermentier",
     "icon": "resources/ALTB.png",
     "engines": {
@@ -78,6 +78,10 @@
             {
                 "command": "al-toolbox.addRegion",
                 "title": "ALTB: Add region"
+            },
+            {
+                "command": "al-toolbox.generateSetLoadFields",
+                "title": "ALTB: Generate SetLoadFields"
             }
         ],
         "configuration": [

--- a/package.json
+++ b/package.json
@@ -142,6 +142,12 @@
                         "default": false,
                         "description": "Disable all AL Toolbox snippets (requires reload). Our snippets start with 'r'.",
                         "scope": "application"
+                    },
+                    "ALTB.DisableHoverProviders": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Disable Hover Providers (requires reload). AL Toolbox shows the field description on hover.",
+                        "scope": "application"
                     }
                 }
             }

--- a/src/codeGeneration/setLoadFields/setLoadFields.js
+++ b/src/codeGeneration/setLoadFields/setLoadFields.js
@@ -1,0 +1,175 @@
+const vscode = require('vscode');
+
+const lookAheadLineCount = 5;
+const findRecRegex = /^\s*\.\s*(Find(First|Last|Set)?|Get)\s*\(/i;
+const fieldRegex = /^\s*\.\s*("[^"\n]*"|\w+\b)(?!\s*(\(|:=))/i;
+const setLoadFieldsRegex = /^\s*\.\s*SetLoadFields\s*\(([^)]*)/i;
+
+/**
+ * Adds or modifies SetLoadFields from the record at recordPosition.
+ * Field that are used in the current document and are not yet present are added. 
+ * Existing fields won't be removed, even if there is no use found.
+ * 
+ * @param {vscode.TextEditor} textEditor 
+ * @param {vscode.Position} recordPosition 
+ */
+exports.generateSetLoadFields = async function (textEditor, recordPosition) {
+    const document = textEditor.document;
+    const currentWordRange = document.getWordRangeAtPosition(recordPosition);
+    const currentRecName = document.getText(currentWordRange);
+
+    return vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: 'Generate SetLoadFields',
+        cancellable: true
+    }, async (progress, cancellationToken) => {
+        progress.report({ message: `Finding definition for ${currentRecName}...` });
+        const definition = await vscode.commands.executeCommand('vscode.executeDefinitionProvider', document.uri, recordPosition);
+        if (cancellationToken.isCancellationRequested) return;
+        if (definition.length === 0) {
+            vscode.window.showErrorMessage(`No definition found for ${currentRecName}`);
+            return;
+        }
+        if (definition.length !== 1) {
+            vscode.window.showErrorMessage(`Multiple definitions found for ${currentRecName}`);
+            return;
+        }
+        
+        let endOfDefinitionPos;
+        if (definition[0].uri.fsPath !== document.uri.fsPath)
+            endOfDefinitionPos = currentWordRange.end;
+        else
+            endOfDefinitionPos = definition[0].range.end;
+        
+        if (!checkIfIsRecord(endOfDefinitionPos, document)) {
+            vscode.window.showErrorMessage(`${currentRecName} is not a Record`);
+            return;
+        }
+        if (!checkIfIsLocalVar(endOfDefinitionPos, document)) {
+            vscode.window.showErrorMessage(`${currentRecName} is not a local Record`);
+            return;
+        }
+
+        // Get all used fields and find/get positions
+        progress.report({ message: 'Searching for used fields...' });
+        const locations = await vscode.commands.executeCommand('vscode.executeReferenceProvider', document.uri, textEditor.selection.start);
+        const positions = locations
+            .filter(location => location.uri.fsPath === document.uri.fsPath)
+            .map(location => location.range.end) 
+            .sort();
+        if (cancellationToken.isCancellationRequested) return;
+
+        let currentGetOfFindRecPos, currentFields = [], currentSetLoadFields, latestSetLoadFields, match, fieldsAdded;
+        let setLoadFieldsAddedOrModified = 0, totalFieldsAdded = 0;
+
+        progress.report({ message: 'Calculating new SetLoadFields...' });
+        await textEditor.edit(edit => {
+            // Checks for each position if it's followed by a field, Get/Find methode, or SetLoadFields method
+            // Then it use this information to add or modify SetLoadFields with the found fields. This only adds fields, so even if no use for a field is found it won't be removed
+            positions.forEach(position => {
+                const text = document.getText(new vscode.Range(position, position.translate(lookAheadLineCount)));
+                if (findRecRegex.test(text)) {
+                    if (currentGetOfFindRecPos) {
+                        fieldsAdded = addOrModifySetLoadFieldsToEdit(edit, currentGetOfFindRecPos, currentFields, document, currentSetLoadFields, currentRecName);
+                        if (fieldsAdded > 0) {
+                            ++setLoadFieldsAddedOrModified;
+                            totalFieldsAdded += fieldsAdded;
+                        }
+                    }
+                    currentGetOfFindRecPos = position;
+                    currentSetLoadFields = latestSetLoadFields;
+                    latestSetLoadFields = undefined;
+                    currentFields = [];
+                }
+                else if ((match = fieldRegex.exec(text)) && !currentFields.includes(match[1]))
+                    currentFields.push(match[1]);
+                else if ((match = setLoadFieldsRegex.exec(text))) {
+                    latestSetLoadFields = {
+                        existingFields: match[1].split(/\s*,\s*/).map(field => field.trim()).filter(field => field !== ''),
+                        endPosition: document.positionAt(document.offsetAt(position) + match[0].length)
+                    };
+                }
+            });
+            if (currentGetOfFindRecPos) {
+                fieldsAdded = addOrModifySetLoadFieldsToEdit(edit, currentGetOfFindRecPos, currentFields, document, currentSetLoadFields, currentRecName);
+                if (fieldsAdded > 0) {
+                    ++setLoadFieldsAddedOrModified;
+                    totalFieldsAdded += fieldsAdded;
+                }
+            }
+        });
+
+        return {
+            fieldsAddedCount: totalFieldsAdded,
+            setLoadFieldsAddedOrModifiedCount: setLoadFieldsAddedOrModified
+        }
+    });
+}
+
+/**
+ * @param {vscode.Position} endOfDefinitionPos 
+ * @param {vscode.TextDocument} document 
+ */
+function checkIfIsRecord(endOfDefinitionPos, document) {
+    const text = document.getText(
+        new vscode.Range(endOfDefinitionPos, endOfDefinitionPos.translate(lookAheadLineCount))
+    );
+    const isRecord = /^(\s*,\s*("[^"\n]*"|\w+))*\s*:\s*Record\b/i.test(text);
+    return isRecord;
+}
+
+/**
+ * functionWithVarsRegex finds a function declaration with vars. The text to be matched must end just before the start of a type declaration of a var.
+ * e.g.:
+ * +---------------------------------------+
+ * | ...                                   |
+ * | procedure test(): Boolean;            |
+ * | var                                   |
+ * |     WebResponse: HttpResponseMessage; |
+ * |     Loop, I : Integer;                |
+ * |     RecordVar$                        |
+ * +---------------------------------------+
+ * where $ is the end of the string.     
+ */
+const functionWithVarsRegex = /\b(procedure|trigger)\s+("[^"\n]*"|\w+)\s*\(((var)?\s*((\b\w+\b|"[^"]*")\s*)+:\s*\w+\b[^;]*;?)*\s*\)\s*((\w+|"[^"]*")?\s*:\s*\w+)?(\s*;)?\s+var(\s*((\b\w+\b|"[^"]*")\s*,?\s*)+:\s*\w+\b[^;]*;)*\s*((\b\w+\b|"[^"]*")\s*,?\s*)+\s*$/i;
+
+/**
+ * @param {vscode.Position} endOfDefinitionPos 
+ * @param {vscode.TextDocument} document 
+ */
+function checkIfIsLocalVar(endOfDefinitionPos, document) {
+    const text = document.getText(new vscode.Range(
+        new vscode.Position(0, 0), endOfDefinitionPos
+    ));
+
+    return functionWithVarsRegex.test(text);
+}
+
+/**
+ * 
+ * @param {vscode.TextEditorEdit} edit 
+ * @param {vscode.Position} position 
+ * @param {Array<string>} fields 
+ * @param {vscode.TextDocument} document 
+ * @param {{ existingFields: Array<string>, endPosition: vscode.Position }} loadFieldsInfo 
+ * @param {string} recName 
+ * 
+ * @returns number of fields added
+ */
+function addOrModifySetLoadFieldsToEdit(edit, position, fields, document, loadFieldsInfo, recName) {
+    if (fields.length === 0) return 0;
+    const line = document.lineAt(position.line);
+    const indent = line.text.substr(0, line.firstNonWhitespaceCharacterIndex);
+    if (loadFieldsInfo) {
+        fields = fields.filter(field => !loadFieldsInfo.existingFields.includes(field));
+        if (fields.length === 0) return 0;
+        edit.insert(
+            loadFieldsInfo.endPosition,
+            `${loadFieldsInfo.existingFields.length === 0 ? '' : ', '}${fields.join(', ')}`);
+    } else
+        edit.insert(
+            line.range.start,
+            `${indent}${recName}.SetLoadFields(${fields.join(', ')});\n`
+        );
+    return fields.length;
+}

--- a/src/codeGeneration/setLoadFields/setLoadFields.js
+++ b/src/codeGeneration/setLoadFields/setLoadFields.js
@@ -2,7 +2,7 @@ const vscode = require('vscode');
 
 const lookAheadLineCount = 5;
 const findRecRegex = /^\s*\.\s*(Find(First|Last|Set)?|Get)\s*\(/i;
-const fieldRegex = /^\s*\.\s*("[^"\n]*"|\w+\b)(?!\s*(\(|:=))/i;
+const fieldRegex = /^\s*\.\s*(TestField\(\s*)?(?<field>"[^"\n]*"|\w+\b)(?!\s*(\(|:=))/i;
 const setLoadFieldsRegex = /^\s*\.\s*SetLoadFields\s*\(([^)]*)/i;
 
 /**
@@ -82,7 +82,7 @@ exports.generateSetLoadFields = async function (textEditor, recordPosition) {
                     currentFields = [];
                 }
                 else if ((match = fieldRegex.exec(text)) && !currentFields.includes(match[1]))
-                    currentFields.push(match[1]);
+                    currentFields.push(match.groups.field);
                 else if ((match = setLoadFieldsRegex.exec(text))) {
                     latestSetLoadFields = {
                         existingFields: match[1].split(/\s*,\s*/).map(field => field.trim()).filter(field => field !== ''),

--- a/src/extension.js
+++ b/src/extension.js
@@ -11,6 +11,7 @@ const AlCodeActionProvider = require('./codeFixers/AlCodeActionProvider');
 const initGitignore = require('./initGitignore/initGitignore');
 const regionFolding = require('./language/regionFolding');
 const indentFolding = require('./language/indentFolding');
+const fieldHover = require('./language/fieldHover');
 const contextSnippets = require('./contextSnippets/contextSnippets');
 const textColoring = require('./textColoring/textColoring');
 const setLoadFields = require('./codeGeneration/setLoadFields/setLoadFields');
@@ -22,6 +23,7 @@ let regionColorManager;
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
+    const config = vscode.workspace.getConfiguration('ALTB');
     //#region Commands
     //#region Related Tables
     context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.createRelatedTables', async () => {
@@ -166,7 +168,7 @@ function activate(context) {
     context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.initGitignore', () => {
         initGitignore.initGitignore();
     }));
-    
+
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('al-toolbox.generateSetLoadFields', textEditor => {
         setLoadFields.generateSetLoadFields(textEditor, textEditor.selection.start).then(result => {
             if (result)
@@ -179,7 +181,7 @@ function activate(context) {
     //#endregion
 
     //#region Unique EntityNames & EntitySetName on API Pages
-    const disableAPIEntityWarnings = vscode.workspace.getConfiguration('ALTB').get('DisableAPIEntityWarnings');
+    const disableAPIEntityWarnings = config.get('DisableAPIEntityWarnings');
     if (!disableAPIEntityWarnings){
         const apiPageEntityAnalyzer = new uniqueApiEntities.ApiPageEntityAnalyzer();
         
@@ -215,17 +217,22 @@ function activate(context) {
             new AlCodeActionProvider.AlCodeActionProvider(context),
             { providedCodeActionKinds: [vscode.CodeActionKind.QuickFix] }
     ));
+    if(!config.get('DisableHoverProviders'))
+        context.subscriptions.push(vscode.languages.registerHoverProvider(
+            'al', new fieldHover.FieldHoverProvider()
+        ));
 
-    const disableCustomFolding = vscode.workspace.getConfiguration('ALTB').get('DisableCustomFolding');
+    const disableCustomFolding = config.get('DisableCustomFolding');
     if (!disableCustomFolding) {
         context.subscriptions.push(vscode.languages.registerFoldingRangeProvider('al', new regionFolding.RegionFoldingRangeProvider()));
         context.subscriptions.push(vscode.languages.registerFoldingRangeProvider('al', new indentFolding.IndentFoldingRangeProvider()));
     }
 
-    const disableSnippets = vscode.workspace.getConfiguration('ALTB').get('DisableSnippets');
+    const disableSnippets = config.get('DisableSnippets');
     if (!disableSnippets) context.subscriptions.push(
         vscode.languages.registerCompletionItemProvider('al', new contextSnippets.SnippetCompletionItemProvider())
     );
+    
     regionColorManager = new textColoring.RegionColorManager(context);
 }
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -166,6 +166,16 @@ function activate(context) {
     context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.initGitignore', () => {
         initGitignore.initGitignore();
     }));
+    
+    context.subscriptions.push(vscode.commands.registerTextEditorCommand('al-toolbox.generateSetLoadFields', textEditor => {
+        setLoadFields.generateSetLoadFields(textEditor, textEditor.selection.start).then(result => {
+            if (result)
+                if (result.fieldsAddedCount > 0) vscode.window.showInformationMessage(
+                    `${result.fieldsAddedCount} field${result.fieldsAddedCount !== 1 ? 's' : ''} added over ${result.setLoadFieldsAddedOrModifiedCount} SetLoadField${result.setLoadFieldsAddedOrModifiedCount !== 1 ? 's' : ''}`); 
+                else
+                    vscode.window.showInformationMessage('No fields added');
+        });
+    }));
     //#endregion
 
     //#region Unique EntityNames & EntitySetName on API Pages
@@ -217,16 +227,6 @@ function activate(context) {
         vscode.languages.registerCompletionItemProvider('al', new contextSnippets.SnippetCompletionItemProvider())
     );
     regionColorManager = new textColoring.RegionColorManager(context);
-
-    context.subscriptions.push(vscode.commands.registerTextEditorCommand('al-toolbox.generateSetLoadFields', textEditor => {
-        setLoadFields.generateSetLoadFields(textEditor, textEditor.selection.start).then(result => {
-            if (result)
-                if (result.fieldsAddedCount > 0) vscode.window.showInformationMessage(
-                    `${result.fieldsAddedCount} field${result.fieldsAddedCount !== 1 ? 's' : ''} added over ${result.setLoadFieldsAddedOrModifiedCount} SetLoadField${result.setLoadFieldsAddedOrModifiedCount !== 1 ? 's' : ''}`); 
-                else
-                    vscode.window.showInformationMessage('No fields added');
-        });
-    }));
 }
 
 // this method is called when your extension is deactivated

--- a/src/extension.js
+++ b/src/extension.js
@@ -13,6 +13,7 @@ const regionFolding = require('./language/regionFolding');
 const indentFolding = require('./language/indentFolding');
 const contextSnippets = require('./contextSnippets/contextSnippets');
 const textColoring = require('./textColoring/textColoring');
+const setLoadFields = require('./codeGeneration/setLoadFields/setLoadFields');
 
 let fileSystemWatchers = new Map();
 let regionColorManager;
@@ -21,9 +22,6 @@ let regionColorManager;
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-  
     //#region Commands
     //#region Related Tables
     context.subscriptions.push(vscode.commands.registerCommand('al-toolbox.createRelatedTables', async () => {
@@ -219,6 +217,16 @@ function activate(context) {
         vscode.languages.registerCompletionItemProvider('al', new contextSnippets.SnippetCompletionItemProvider())
     );
     regionColorManager = new textColoring.RegionColorManager(context);
+
+    context.subscriptions.push(vscode.commands.registerTextEditorCommand('al-toolbox.generateSetLoadFields', textEditor => {
+        setLoadFields.generateSetLoadFields(textEditor, textEditor.selection.start).then(result => {
+            if (result)
+                if (result.fieldsAddedCount > 0) vscode.window.showInformationMessage(
+                    `${result.fieldsAddedCount} field${result.fieldsAddedCount !== 1 ? 's' : ''} added over ${result.setLoadFieldsAddedOrModifiedCount} SetLoadField${result.setLoadFieldsAddedOrModifiedCount !== 1 ? 's' : ''}`); 
+                else
+                    vscode.window.showInformationMessage('No fields added');
+        });
+    }));
 }
 
 // this method is called when your extension is deactivated

--- a/src/language/fieldHover.js
+++ b/src/language/fieldHover.js
@@ -1,0 +1,36 @@
+const vscode = require('vscode');
+
+const descriptionRegex = /^\s*;\s*\w+\s*\[\s*\d+\s*\]\s*\)\s*\{(\s*\w+\s*=[^;]*;)*\s*description\s*=\s*'(?<description>([^']|'')*)';/i;
+
+exports.FieldHoverProvider = class FieldHoverProvider {
+    
+    /**
+     * returns the Description of a field
+     * 
+     * @param {vscode.TextDocument} document 
+     * @param {vscode.Position} position 
+     * @param {vscode.CancellationToken} token 
+     * 
+     * @returns {vscode.ProviderResult<vscode.Hover>}
+     */
+    provideHover(document, position, token) {
+        return vscode.commands.executeCommand('vscode.executeDefinitionProvider', document.uri, position)
+            .then(definitions => {
+                if (token.isCancellationRequested) return Promise.reject('Canceled');
+                if (definitions.length !== 1) return Promise.reject('No or multiple definitions found');
+                return definitions[0];
+            }).then(definition => {
+                return vscode.workspace.openTextDocument(definition.uri).then(textDocument => {
+                    if (token.isCancellationRequested) return Promise.reject('Canceled');
+
+                    const text = textDocument.getText(new vscode.Range(
+                        definition.range.end, textDocument.lineAt(textDocument.lineCount-1).range.end
+                    ));
+                    const match = descriptionRegex.exec(text);
+                    if (!match) return Promise.reject('No definition found');
+                    const description = match.groups.description;
+                    return new vscode.Hover(description);
+                });
+            });
+    }
+}


### PR DESCRIPTION
Added Command: "ALTB: Generate SetLoadFields" 
- Creates SetLoadFields or adds missing fields to SetLoadFields for a record.
- Looks for a record at the current mouse position.
- Only works for local records.
- For each Get, Find, FindFirst, ... a SetLoadFields function is generated the line before it, unless it already exists.
- All used fields are added. Assignment is not seen as usage.

Added Hover Provider:
- shows the field description on hover
![image](https://user-images.githubusercontent.com/61057232/98089999-c9325480-1e83-11eb-8639-d03fe7a44b41.png)
![image](https://user-images.githubusercontent.com/61057232/98090166-f7179900-1e83-11eb-8cd4-263bf25db131.png)

