### PR TITLE
#31 & #32 Renumber fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,3 +96,8 @@ Added Command:
 
 ## [2.0.6]
 - Added option for checking format of label comments required by the 'AL Language Tools' extension for generating XLIFF files: ALTB.CheckCommentTranslations
+
+## [2.0.8]
+- Added commands:
+  - ALTB: Renumber fields | Renumbers field numbers in the active editor
+  - ALTB: Renumber all fields | Renumbers fields in all tables and table extensions objects (in all workspace folders). 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,13 @@ Automatic fix for AL(AA0139)
 - ALTB: Renumber AL Objects | This function will renumber your objects based on the number ranges in the App.json
     - Objects will be numbered in ascending order stating with the lowest number in first available range. The ranges are taken from idRange(s) in the app.json file.
     - Extension objects will be added to the 80,000-89,999 range if 80,000 is in the available ranges. If not the same is done as for the other objects.
+- ALTB: Renumber fields | Renumbers field numbers in the active editor
+- ALTB: Renumber all fields | Renumbers fields in all tables and table extensions objects (in all workspace folders). 
 ## Action: Change Object Prefix
 - ALTB: Change Object Prefix | This function will ask you what the new prefix should be and rename all your objects and the settings.json.
 ## Action: Create Related Tables
 This will create a set of tableextensions that should have the same fields so that there is no issue when standard code issues a TransferFields().
+
 ![RelatedTables](resources/RelatedTables.png)
 ## Action: Open Related Tables
 - ALTB: Open Related Tables/Pages | This function will open the related tables/pages for the object you are working on, so you can easily copy paste fields between the related tables of Sales Header for example.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "al-toolbox",
     "displayName": "AL Toolbox",
     "description": "AL Language Regions and Snippets",
-    "version": "2.0.7",
+    "version": "2.0.8",
     "publisher": "BartPermentier",
     "icon": "resources/ALTB.png",
     "engines": {
@@ -26,7 +26,8 @@
         "onCommand:al-toolbox.createRelatedTables",
         "onCommand:al-toolbox.renumberAll",
         "onCommand:al-toolbox.changePrefix",
-        "onCommand:al-toolbox.initGitignore"
+        "onCommand:al-toolbox.initGitignore",
+        "onCommand:al-toolbox.renumberAllFields"
     ],
     "main": "./src/extension.js",
     "contributes": {
@@ -82,6 +83,14 @@
             {
                 "command": "al-toolbox.generateSetLoadFields",
                 "title": "ALTB: Generate SetLoadFields"
+            },
+            {
+                "command": "al-toolbox.renumberFields",
+                "title": "ALTB: Renumber fields"
+            },
+            {
+                "command": "al-toolbox.renumberAllFields",
+                "title": "ALTB: Renumber all fields"
             }
         ],
         "configuration": [

--- a/src/renumberObjects/renumberFields.js
+++ b/src/renumberObjects/renumberFields.js
@@ -1,0 +1,82 @@
+const vscode = require('vscode');
+const alFileManagement = require('../fileManagement/alFileManagement');
+const constants = require('../constants');
+
+const fieldRegex = /(?<=\bfield\s*\(\s*)\d+(?=\s*;)/g;
+
+/**
+ * @param {vscode.TextDocument} document 
+ * @param {vscode.WorkspaceEdit} edit
+ * @param {number} startFrom The new numbers will start form this number, counting up.
+ */
+function addRenumberFieldsToEdit(document, edit, startFrom) {
+    let text = document.getText();
+
+    let match, fieldNoAndRange = [];
+    while((match = fieldRegex.exec(text))) {
+        const startPos = document.positionAt(match.index);
+        fieldNoAndRange.push({
+            no: Number(match[0]),
+            range: new vscode.Range(startPos, startPos.translate(0, match[0].length))
+        });
+    }
+
+    if (fieldNoAndRange.length === 0) return false;
+    
+    fieldNoAndRange
+        .sort((a, b) => a.no - b.no)
+        .forEach(fieldInfo => edit.replace(document.uri, fieldInfo.range, `${startFrom++}`));
+    return true  
+}
+
+/**
+ * @param {vscode.TextDocument} document 
+ * @param {number} startFrom The new numbers will start form this number, counting up.
+ */
+async function renumberFields(document, startFrom) {
+    const edit = new vscode.WorkspaceEdit();
+    if (addRenumberFieldsToEdit(document, edit, startFrom))
+        return await vscode.workspace.applyEdit(edit);
+    else
+        return false;
+}
+exports.renumberFields = renumberFields;
+
+/**
+ * @param {number} startFromForTable The new numbers for tables will start form this number, counting up.
+ * @param {number} startFromForTableExtension The new numbers table extension will start form this number, counting up.
+ */
+async function renumberAllFields(startFromForTable, startFromForTableExtension) {
+    const uris = await vscode.workspace.findFiles('**/*.al');
+
+    const increment = 100 / uris.length;
+    const results = await vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: "Updating prefixes...",
+        cancellable: false
+    }, async progress => {
+
+        return Promise.all(uris.map(uri => vscode.workspace.openTextDocument(uri).then(async document => {
+                const objInfo = new alFileManagement.AlObjectInfo(document);
+                let edited = false;
+                switch (objInfo.type) {
+                    case constants.AlObjectTypes.table:
+                        edited = await renumberFields(document, startFromForTable);
+                        break;
+                    case constants.AlObjectTypes.tableExtension:
+                        edited = await renumberFields(document, startFromForTableExtension);
+                        break;
+                }
+                progress.report({increment: increment});
+                return edited;
+            })
+        ));
+    })
+    
+    let docEditedCount = 0;
+    results.forEach(edited => {
+        if (edited) ++docEditedCount;    
+    });
+    return docEditedCount;
+}
+exports.renumberAllFields = renumberAllFields;


### PR DESCRIPTION
- Added commands:
  - ALTB: Renumber fields | Renumbers fields in the active editor
  - ALTB: Renumber all fields | Renumbers fields in all tables and table extensions objects (in all workspace folders). 