### PR TITLE
Bugfix for version comparison (#80)

### DIFF
--- a/src/generalFunctions.js
+++ b/src/generalFunctions.js
@@ -16,7 +16,7 @@ exports.useAlRegions = async function () {
         if (file) {
             const json = JSON.parse(file.getText());
             if (json && json.runtime) {
-                const runtime = parseInt(json.runtime.charAt(0));
+                const runtime = parseInt(json.runtime.split('.')[0]);
                 if (runtime >= 6)
                     return true;
             }


### PR DESCRIPTION
Major version of BC should be greater than 6, not just the first character of the version string. 

fixes #80 