### PR TITLE
Add ractionRef snippet

### DIFF
--- a/src/contextSnippets/snippets.js
+++ b/src/contextSnippets/snippets.js
@@ -561,6 +561,15 @@ exports.snippets = {
 			"}"
 		]
 	},
+	"Snippet: ActionRef": {
+        "prefix": "ractionRef (ALTB)",
+        "body": [
+            "actionref(${1/[^0-9^a-z]//gi}_Promoted; ${1:ActionName})",
+            "{",            
+            "}"
+        ],
+        "description": "Promoted ActionRef"
+    },
 	"Snippet: DelChr": {
 		"prefix": "rDelChr (ALTB)",
 		"body": [


### PR DESCRIPTION
New ractionRef snippet which allows to faster create an `actionRef` block with a predefined name, using the (copied) name of the action.

- ActionRef control name is created used the stripped ActionName (no special chars, spaces, ", ...) + '_Promoted'
- Use case: first copy the action name from the action you like to promote. Then use the snippet and paste the action name.

![actionRef2](https://user-images.githubusercontent.com/25268332/194513100-6257ca39-c535-4740-9c55-406f0ea8e414.gif)
