### PR TITLE
Possible fix for #88

### DIFF
--- a/src/fileManagement/fileManagement.js
+++ b/src/fileManagement/fileManagement.js
@@ -37,9 +37,9 @@ exports.createFolder = createFolder;
 //#endregion
 
 async function findSingleInstanceFileInCurrentWorkspaceFolder(file) {
-    const currentWorkspaceFolderPath = workspaceManagement.getCurrentWorkspaceFolderPath();
-    let files = await vscode.workspace.findFiles(`**/${file}`);
-    files = files.filter(file => file.fsPath.startsWith(currentWorkspaceFolderPath));
+    const currentWorkspaceFolder = workspaceManagement.getCurrentWorkspaceFolder();
+    const relativePattern = new vscode.RelativePattern(currentWorkspaceFolder, `**/${file}`);
+    const files = await vscode.workspace.findFiles(relativePatter);
 
     if (files.length === 0) throw `No ${file} found`;
     if (files.length > 1)


### PR DESCRIPTION
This should fix issue #88.

Instead of looking for file paths that start with the current folder, this searches just in the current folder. So if we are in "app" we would find only "app/app.json" and not "app2/app.json", even though they both begin with "app".

I did not test this at all, I was just looking through the documentation:

https://code.visualstudio.com/api/references/vscode-api#workspace.findFiles
https://code.visualstudio.com/api/references/vscode-api#RelativePattern